### PR TITLE
Minor tweak to make meck work with rebar/cover_enabled=true

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -454,7 +454,12 @@ backup_original(Module) ->
 restore_original(_Mod, false) ->
     ok;
 restore_original(Mod, {File, Data, Options}) ->
-    {ok, Mod} = cover:compile(File, Options),
+    case filename:extension(File) of
+        ".erl" ->
+            {ok, Mod} = cover:compile_module(File, Options);
+        ".beam" ->
+            cover:compile_beam(File)
+    end,
     ok = cover:import(Data),
     file:delete(Data),
     ok.


### PR DESCRIPTION
Hi,

Thanks for writing meck, it's just what I need for mocking up modules for testing. 

I hit an issue using meck with rebar in eunit tests if {cover_enabled, true} was set in rebar.config.  When rebar runs tests, it recompiles all the source code into a directory called .eunit rather than ebin and calls cover:compile_beam/1 for them.  After that cover:is_compiled returns a .beam file instead of a .erl file, so when restore_original tries it put the module back calling cover:compile on a .beam file blows up.

The patch just adds a simple check on the file extension and compiles appropriately.

Cheers, Jon Meredith
