### PR TITLE
Remove @$Hostname from nodename in remote_setup() in meck_tests()

### DIFF
--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -506,7 +506,7 @@ remote_meck_test_() ->
 
 remote_setup() ->
     {ok, Hostname} = inet:gethostname(),
-    Myself = list_to_atom("meck_eunit_test@" ++ Hostname),
+    Myself = list_to_atom("meck_eunit_test"),
     net_kernel:start([Myself, shortnames]),
     {ok, Node} = slave:start_link(list_to_atom(Hostname), meck_remote_test,
                                   "-pa test"),


### PR DESCRIPTION
The remote test only works with a
    node@host 

style name if epmd is already running. This patch removes the hostname portion of the nodename and the tests then run successfully.
