### PR TITLE
Verify history/2 returns events in the correct order & fix to flaky history_by_pid_/1 test

### DIFF
--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -293,6 +293,7 @@ history_by_pid_(Mod) ->
     Pid = spawn(Fun),
     Mod:test1(),
     Mod:test2(),
+    receive {Pid, done} -> ok end,
     ?assertEqual([{Pid, {Mod, test1, []}, ok}], meck:history(Mod, Pid)),
     ?assertEqual([{TestPid, {Mod, test1, []}, ok},
                   {TestPid, {Mod, test2, []}, ok}], meck:history(Mod, TestPid)),


### PR DESCRIPTION
Hi Adam,

I have made 2 corrections to the test history_by_pid_/1.
1. Verify that the order of the events in the history is correct
2. The test was a little flaky, it would fail sometimes (It has happend to me at least once). So I added a receive to wait for the spawned process to make its call.
