### PR TITLE
Clean test directory

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,4 +3,4 @@
 {dialyzer_opts, [{warnings, [unmatched_returns]}]}.
 
 {cover_enabled, true}.
-{clean_files, [".eunit", "ebin/*.beam"]}.
+{clean_files, [".eunit", "ebin/*.beam", "test/*.beam"]}.


### PR DESCRIPTION
Clean the test directory to remove file test/cover_test_module.beam created by meck's eunit tests.
