### PR TITLE
Support for location included in stack traces in Erlang R15

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -643,6 +643,8 @@ inject(_Mod, _Func, _Args, []) ->
     [];
 inject(Mod, Func, Args, [{meck, exec, _Arity} = Meck|Stack]) ->
     [Meck, {Mod, Func, Args}|Stack];
+inject(Mod, Func, Args, [{meck, exec, _Arity, _Location} = Meck|Stack]) ->
+    [Meck, {Mod, Func, Args}|Stack];
 inject(Mod, Func, Args, [H|Stack]) ->
     [H|inject(Mod, Func, Args, Stack)].
 

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -167,6 +167,7 @@ stacktrace_(Mod) ->
     catch
         error:test_error ->
             ?assert(lists:any(fun({M, test, []}) when M == Mod -> true;
+				 ({M, test, [],[]}) when M == Mod -> true;
                                  (_)                 -> false end,
                               erlang:get_stacktrace()))
     end.
@@ -180,6 +181,7 @@ stacktrace_function_clause_(Mod) ->
         error:function_clause ->
             Stacktrace = erlang:get_stacktrace(),
             ?assert(lists:any(fun({M, test, [error]}) when M == Mod -> true;
+				 ({M, test, [error], []}) when M == Mod -> true;
                                  (_)                      -> false end,
                               Stacktrace))
     end.
@@ -254,6 +256,7 @@ history_error_args_(Mod) ->
                  meck:history(Mod)),
     [{_Pid, _MFA, error, test_error, Stacktrace}] = History,
     ?assert(lists:any(fun({_M, _F, [fake_args]}) -> true;
+			 ({_M, _F, [fake_args], [{file,_},{line,_}]}) -> true;
                          (_) -> false end, Stacktrace)).
 
 history_meck_throw_(Mod) ->


### PR DESCRIPTION
Support added in the meck:inject/4 function and the unit tests to support the new [{file,_},{line,_}] information included in stack traces
