### PR TITLE
Rz passthrough cover

### DIFF
--- a/src/meck_cover.erl
+++ b/src/meck_cover.erl
@@ -1,0 +1,109 @@
+%%==============================================================================
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%==============================================================================
+
+%% @doc Module containing functions needed by meck to integrate with cover.
+
+-module(meck_cover).
+
+%% Interface exports
+-export([compile_beam/2]).
+-export([rename_module/2]).
+
+%%==============================================================================
+%% Interface exports
+%%==============================================================================
+
+%% @doc Enabled cover on `<name>_meck_original'.
+compile_beam(OriginalMod, Bin) ->
+    alter_cover(),
+    {ok, _} = cover:compile_beam(OriginalMod, Bin).
+
+%% @doc Given a cover file `File' exported by `cover:export' overwrite
+%% the module name with `Name'.
+rename_module(File, Name) ->
+    NewTerms = change_cover_mod_name(read_cover_file(File), Name),
+    write_terms(File, NewTerms),
+    ok.
+
+%%==============================================================================
+%% Internal functions
+%%==============================================================================
+
+%% @private
+%%
+%% @doc Alter the cover BEAM module to export some of it's private
+%% functions.  This is done for two reasons:
+%%
+%% 1. Meck needs to alter the export analysis data on disk and
+%% therefore needs to understand this format.  This is why `get_term'
+%% and `write' are exposed.
+%%
+%% 2. In order to avoid creating temporary files meck needs direct
+%% access to `compile_beam/2' which allows passing a binary.
+alter_cover() ->
+    case lists:member({compile_beam,2}, cover:module_info(exports)) of
+        true ->
+            ok;
+        false ->
+            Beam = meck_mod:beam_file(cover),
+            AbsCode = meck_mod:abstract_code(Beam),
+            Exports = [{compile_beam, 2}, {get_term, 1}, {write, 2}],
+            AbsCode2 = meck_mod:add_exports(Exports, AbsCode),
+            meck_mod:compile_and_load_forms(AbsCode2)
+    end.
+
+change_cover_mod_name(CoverTerms, Name) ->
+    {_, Terms} = lists:foldl(fun change_name_in_term/2, {Name,[]}, CoverTerms),
+    Terms.
+
+change_name_in_term({file, Mod, File}, {Name, Terms}) ->
+    Term2 = {file, Name, replace_string(File, Mod, Name)},
+    {Name, [Term2|Terms]};
+change_name_in_term({Bump={bump,_,_,_,_,_},_}=Term, {Name, Terms}) ->
+    Bump2 = setelement(2, Bump, Name),
+    Term2 = setelement(1, Term, Bump2),
+    {Name, [Term2|Terms]};
+change_name_in_term({_Mod,Clauses}, {Name, Terms}) ->
+    Clauses2 = lists:foldl(fun change_name_in_clause/2, {Name, []}, Clauses),
+    Term2 = {Name, Clauses2},
+    {Name, [Term2|Terms]}.
+
+change_name_in_clause(Clause, {Name, NewClauses}) ->
+    {Name, [setelement(1, Clause, Name)|NewClauses]}.
+
+replace_string(File, Old, New) ->
+    Old2 = atom_to_list(Old),
+    New2 = atom_to_list(New),
+    re:replace(File, Old2, New2, [{return, list}]).
+
+read_cover_file(File) ->
+    {ok, Fd} = file:open(File, [read, binary, raw]),
+    Terms = get_terms(Fd, []),
+    file:close(Fd),
+    Terms.
+
+get_terms(Fd, Terms) ->
+    case cover:get_term(Fd) of
+        eof -> Terms;
+        Term -> get_terms(Fd, [Term|Terms])
+    end.
+
+write_terms(File, Terms) ->
+    {ok, Fd} = file:open(File, [write, binary, raw]),
+    lists:map(write_term(Fd), Terms),
+    ok.
+
+write_term(Fd) ->
+    fun(Term) -> cover:write(Term, Fd) end.
+

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -503,7 +503,7 @@ loop_multi_(Mod) ->
 call_original_test() ->
     false = code:purge(meck_test_module),
     ?assertEqual({module, meck_test_module}, code:load_file(meck_test_module)),
-    ok = meck:new(meck_test_module),
+    ok = meck:new(meck_test_module, [no_passthrough_cover]),
     ?assertEqual({file, ""}, code:is_loaded(meck_test_module_meck_original)),
     ok = meck:expect(meck_test_module, a, fun() -> c end),
     ok = meck:expect(meck_test_module, b, fun() -> meck:passthrough([]) end),
@@ -543,7 +543,10 @@ passthrough_nonexisting_module_test() ->
     ok = meck:unload(mymod).
 
 passthrough_test() ->
-    ok = meck:new(meck_test_module, [passthrough]),
+    passthrough_test([]).
+
+passthrough_test(Opts) ->
+    ok = meck:new(meck_test_module, [passthrough|Opts]),
     ok = meck:expect(meck_test_module, a, fun() -> c end),
     ?assertEqual(c, meck_test_module:a()),
     ?assertEqual(b, meck_test_module:b()),
@@ -572,7 +575,9 @@ cover_test() ->
 
 cover_options_test_() ->
     {foreach, fun compile_options_setup/0, fun compile_options_teardown/1,
-     [{with, [T]} || T <- [fun ?MODULE:cover_options_/1]]}.
+     [{with, [T]} || T <- [fun ?MODULE:cover_options_/1,
+                           fun ?MODULE:cover_options_fail_/1
+                          ]]}.
 
 compile_options_setup() ->
     Module = cover_test_module,
@@ -586,6 +591,8 @@ compile_options_setup() ->
 
 compile_options_teardown({OldPath, Src, Module}) ->
     file:rename(Src, join("../test/", Module, ".dontcompile")),
+    code:purge(Module),
+    code:delete(Module),
     code:set_path(OldPath).
 
 cover_options_({_OldPath, Src, Module}) ->
@@ -607,6 +614,31 @@ cover_options_({_OldPath, Src, Module}) ->
     % 2 instead of 3, as above
     ?assertEqual({ok, {Module, {2,0}}}, cover:analyze(Module, module)).
 
+cover_options_fail_({_OldPath, Src, Module}) ->
+    %% This may look like the test above but there is a subtle
+    %% difference.  When `cover:compile_beam' is called it squashes
+    %% compile options.  This test verifies that function `b/0', which
+    %% relies on the `TEST' directive being set can still be called
+    %% after the module is meck'ed.
+    CompilerOptions = [{i, "../test/include"}, {d, 'TEST', true},
+                       {outdir, "../test"}, debug_info],
+    {ok, _} = compile:file(Src, CompilerOptions),
+    ?assertEqual(CompilerOptions, meck_mod:compile_options(Module)),
+    {ok, _} = cover:compile_beam(Module),
+    ?assertEqual([], meck_mod:compile_options(Module)),
+    a      = Module:a(),
+    b      = Module:b(),
+    {1, 2} = Module:c(1, 2),
+    ?assertEqual({ok, {Module, {2,0}}}, cover:analyze(Module, module)),
+    ok = meck:new(Module, [passthrough]),
+    ok = meck:expect(Module, a, fun () -> c end),
+    ?assertEqual(c, Module:a()),
+    ?assertEqual(b, Module:b()),
+    ?assertEqual({1, 2}, Module:c(1, 2)),
+    ok = meck:unload(Module),
+    %% Verify passthru calls went to cover
+    ?assertEqual({ok, {Module, 4}}, cover:analyze(Module, calls, module)).
+
 join(Path, Module, Ext) -> filename:join(Path, atom_to_list(Module) ++ Ext).
 
 run_mock_no_cover_file(Module) ->
@@ -616,11 +648,22 @@ run_mock_no_cover_file(Module) ->
     ok = meck:unload(Module),
     ?assert(not filelib:is_file(atom_to_list(Module) ++ ".coverdata")).
 
-cover_passthrough_test() ->
+%% @doc Verify that passthrough calls _don't_ appear in cover
+%% analysis.
+no_cover_passthrough_test() ->
     {ok, _} = cover:compile("../test/meck_test_module.erl"),
     {ok, {meck_test_module, {0,3}}} = cover:analyze(meck_test_module, module),
-    passthrough_test(),
+    passthrough_test([no_passthrough_cover]),
     {ok, {meck_test_module, {0,3}}} = cover:analyze(meck_test_module, module).
+
+%% @doc Verify that passthrough calls appear in cover analysis.
+cover_passthrough_test() ->
+    {ok, _} = cover:compile("../test/meck_test_module.erl"),
+    ?assertEqual({ok, {meck_test_module, {0,3}}},
+                 cover:analyze(meck_test_module, module)),
+    passthrough_test([]),
+    ?assertEqual({ok, {meck_test_module, {2,1}}},
+                 cover:analyze(meck_test_module, module)).
 
 % @doc The mocked module is unloaded if the meck process crashes.
 unload_when_crashed_test() ->
@@ -772,6 +815,7 @@ sticky_setup() ->
     {ok, _BytesCopied} = file:copy(Beam, Dest),
     true = code:add_patha(Dir),
     ok = code:stick_dir(Dir),
+    code:load_file(Module),
 
     {Module, {Dir, Dest}}.
 


### PR DESCRIPTION
EDIT: Collecting cover data on a mocked module is the default now.  To disable the feature use `no_passthrough_cover` option.

This patch adds a `pass_cover` option which will allow coverage analysis to be collected for `passthrough` calls.

Feel free to nitpick the PR for anything.  No ego here.  Just want to see this ability in meck.

Technically, I don't think the last commit `6a7ad20a` is needed, but I thought I'd leave it in and let you decide.  I spent a lot of time pulling my hair trying to understand how the code server, rebar, cover, and meck all interact with each other.  I'm pretty happy with this solution.  I'd like it even better if I didn't have to manually tease apart the cover data but I didn't see another way.
