### PR TITLE
fix bad match error when cover data file not exists.

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -678,7 +678,9 @@ restore_original(Mod, {File, Data, Options}, WasSticky) ->
     restick_original(Mod, WasSticky),
 	case cover:import(Data) of
 		ok ->
-			ok = file:delete(Data)
+			ok = file:delete(Data);
+		{error, Reason} ->
+			io:format("Cover import failure : ~p~n", [Reason])
 	end,
     ok.
 


### PR DESCRIPTION
It's quite minor fix. 
Sometimes a test with meck would fail when cover data file didn't generate by any reason.
