### PR TITLE
Add original module attributes to meck'd module 

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -581,7 +581,16 @@ contains_opaque(_Term) ->
 
 to_forms(Mod, Expects) ->
     {Exports, Functions} = functions(Mod, Expects),
-    [?attribute(module, Mod)] ++ Exports ++ Functions.
+    [?attribute(module, Mod)] ++ attributes(Mod) ++ Exports ++ Functions.
+
+attributes(Mod) ->
+    try
+        [?attribute(Key, Val) || {Key, Val} <-
+            proplists:get_value(attributes, Mod:module_info(), []),
+            Key =/= vsn]
+    catch
+        error:undef -> []
+    end.
 
 functions(Mod, Expects) ->
     dict:fold(fun(Export, Expect, {Exports, Functions}) ->

--- a/test/meck_test_module.erl
+++ b/test/meck_test_module.erl
@@ -1,4 +1,5 @@
 -module(meck_test_module).
+-tag(foobar).
 -export([a/0, b/0, c/2]).
 
 a() -> a.

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -877,6 +877,13 @@ meck_parametrized_module_passthrough_test() ->
     ?assertEqual({mecked, var2}, Object:var2()),
     ?assertEqual(ok, meck:unload(meck_test_parametrized_module)).
 
+meck_module_attributes_test() ->
+    ?assertEqual(ok, meck:new(meck_test_module)),
+    ?assertEqual([foobar], proplists:get_value(tag,
+                                proplists:get_value(attributes,
+                                    meck_test_module:module_info()))),
+    ?assertEqual(ok, meck:unload(meck_test_module)).
+
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================


### PR DESCRIPTION
meck omits original module attributes, for example:

<pre>
1> proplists:get_value(attributes, supervisor:module_info()).
[{vsn,[114474700268360949500192371998556367091]},
 {behaviour,[gen_server]}]
2> meck:new(supervisor, [unstick]).
ok
3> proplists:get_value(attributes, supervisor:module_info()).
[{vsn,[118933215264849542400101025310352563009]}]
</pre>


Given patch resolves the issue.
