### PR TITLE
Treat references as opaque in meck:contains_opaque/1

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -569,7 +569,8 @@ func_native(Mod, Func, Arity, Result) ->
                                    AbsResult])])]),
             AbsResult])]).
 
-contains_opaque(Term) when is_pid(Term); is_port(Term); is_function(Term) ->
+contains_opaque(Term) when is_pid(Term); is_port(Term); is_function(Term);
+                           is_reference(Term) ->
     true;
 contains_opaque(Term) when is_list(Term) ->
     lists:any(fun contains_opaque/1, Term);


### PR DESCRIPTION
erl_parse:abstract/1 chokes on references.  Make sure we don't feed it
any by making contains_opaque/1 return true for anything that contains
a reference.
