### PR TITLE
Feature/verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,9 @@ tags
 .*.swp
 .settings
 .project
+<<<<<<< HEAD
 *.sublime-workspace
 *.sublime-project
+=======
+*~
+>>>>>>> e5d147d... Introduce family of meck:verify functions


### PR DESCRIPTION
I would like to suggest extending the **meck** API with a family of **verify** functions. They are inspired by <a href="http://code.google.com/p/mockito/">Mockito</a> Java mocking framework and its <a href="http://docs.mockito.googlecode.com/hg/latest/org/mockito/Mockito.html#4">verify</a> capabilities in particular.

The idea behind **verify** that it checks a condition and either succeeds of raises a runtime error. It does not need to be wrapped in any ?assert(...) function, it is assertion itself. Therefore it makes tests a little bit shorter.

If the specified condition is not meant then a nice readable error message is displayed. Consider:

meck:verify({at_least, 3}, mymod, test, ['_', 2, '_']).

{"Unexpected number of calls",
 {pattern,{mymod,test,['_',2,'_']}},
 {expected,{at_least,3}},
 {actual,2}}

As you probably noticed **verify** effectively covers functionality provided by **called** and **num_calls** and adds more that is not yet present (like **at_least** and **at_most** predicates)

If you approve such API extension then I will add another function to this family that will receive a list of calls specs along with times to verify that a particular call order has been adhered.
