### PR TITLE
Introduce 'stub_all' option

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -659,18 +659,20 @@ resolve_can_expect(Exports, Options) ->
 
 init_expects(Exports, Options) ->
     Passthrough = proplists:get_bool(passthrough, Options),
-    StubRet = proplists:get_value(stub_all, Options),
+    StubAll = proplists:is_defined(stub_all, Options),
     Expects = case Exports of
                   undefined ->
                       [];
                   Exports when Passthrough ->
                       [passthrough_stub(FuncArity) || FuncArity <- Exports];
-                  Exports when StubRet =:= undefined ->
-                      [];
-                  Exports when StubRet =:= true ->
-                      [void_stub(FuncArity, val(ok)) || FuncArity <- Exports];
+                  Exports when StubAll ->
+                      StubRet = case lists:keyfind(stub_all, 1, Options) of
+                                    {stub_all, RetSpec} -> RetSpec;
+                                    _ -> val(ok)
+                                end,
+                      [void_stub(FuncArity, StubRet) || FuncArity <- Exports];
                   Exports ->
-                      [void_stub(FuncArity, StubRet) || FuncArity <- Exports]
+                      []
               end,
     dict:from_list(Expects).
 

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -825,17 +825,9 @@ passthrough_bif_test() ->
     ?assertEqual(ok, meck:new(file, [unstick, passthrough])),
     ?assertEqual(ok, meck:unload(file)).
 
-stub_all_default_test() ->
-    ok = meck:new(meck_test_module, [stub_all]),
-    ok = meck:expect(meck_test_module, a, fun() -> c end),
-    ?assertEqual(c, meck_test_module:a()),
-    ?assertEqual(ok, meck_test_module:b()),
-    ?assertEqual(ok, meck_test_module:c(1, 2)),
-    ok = meck:unload(meck_test_module).
-
-stub_all_ret_spec_test() ->
+stub_all_test() ->
     ok = meck:new(meck_test_module, [{stub_all, meck:seq([a, b])}]),
-    ok = meck:expect(meck_test_module, a, fun() -> c end),
+    ok = meck:expect(meck_test_module, a, [], c),
     ?assertEqual(c, meck_test_module:a()),
     ?assertEqual(a, meck_test_module:b()),
     ?assertEqual(b, meck_test_module:b()),
@@ -843,6 +835,21 @@ stub_all_ret_spec_test() ->
     ?assertEqual(a, meck_test_module:c(1, 2)),
     ?assertEqual(b, meck_test_module:c(1, 2)),
     ?assertEqual(b, meck_test_module:c(1, 2)),
+    ok = meck:unload(meck_test_module).
+
+stub_all_default_test() ->
+    ok = meck:new(meck_test_module, [stub_all]),
+    ?assertEqual(ok, meck_test_module:c(1, 2)),
+    ok = meck:unload(meck_test_module).
+
+stub_all_undefined_test() ->
+    ok = meck:new(meck_test_module, [{stub_all, undefined}]),
+    ?assertEqual(undefined, meck_test_module:c(1, 2)),
+    ok = meck:unload(meck_test_module).
+
+stub_all_true_test() ->
+    ok = meck:new(meck_test_module, [{stub_all, true}]),
+    ?assertEqual(true, meck_test_module:c(1, 2)),
     ok = meck:unload(meck_test_module).
 
 stub_all_overridden_by_passthrough_test() ->


### PR DESCRIPTION
For those who use mocks in record-then-verify manner (and I am one of them :-)) it would be very convenient to create mocks that have stubs for all exported functions out-of-the-box. This feature introduces such capability. The default stubs allow everything as input arguments and return <code>meck_stub</code>. If in the scope of a test a more specific stub (expectation) is required, then the out-of-the-box stub (expectation) can be overridden by explicit call to <code>meck:expect/3,4</code>.

E.g. If there is a module <code>m1</code> that exports function <code>f/2</code> then:

```
meck:new(m1, [stub_all]),
?assertEquals(meck_stub, m1:f(blah, whatever)).
```
