### PR TITLE
Fix warning in R16B

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -21,7 +21,8 @@
 -module(meck).
 
 %% API
--export_type([args_spec/0,
+-export_type([matcher/0,
+              args_spec/0,
               ret_spec/0,
               func_clause_spec/0]).
 


### PR DESCRIPTION
With this commit you can compile by R16B using rebar.
(Also it works in R15)

Warning was: "src/meck.erl:78: opaque type matcher() is not exported"
