### PR TITLE
Remove unsupported option from the app.src file

### DIFF
--- a/src/meck.app.src
+++ b/src/meck.app.src
@@ -5,5 +5,4 @@
   {modules, []},
   {registered, []},
   {applications, [kernel, stdlib]},
-  {build_dependencies, []},
   {env, []}]}.


### PR DESCRIPTION
Key `build_dependencies` currently specified in the .app files isn't recognized by Erlang release tools (systools and reltool). This is a non-standard key that is unsupported by those tools, causing warnings every time the .app files is processed by those tools (which happens when creating releases or calling most of the functions available in either systools or reltool modules). It seems that the key is not used anyway so I think it should be safe to remove it, but if indeed it serves an unknown to me purpose please let me know and I will be happy to update the code as well.

The list of keys supported by the release tools is available here: [http://www.erlang.org/doc/design_principles/applications.html#id73724](http://www.erlang.org/doc/design_principles/applications.html#id73724)
