### PR TITLE
Implement 'implicit new' feature #80

### DIFF
--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -1235,6 +1235,12 @@ meck_module_attributes_test() ->
                                     meck_test_module:module_info()))),
     ?assertEqual(ok, meck:unload(meck_test_module)).
 
+meck_implicit_new_test()->
+    meck:expect(meck_test_module, c, [{[1, 1], foo},
+                                      {['_', '_'], bar}]),
+    ?assertMatch(foo, meck_test_module:c(1, 1)),
+    meck:unload().
+
 %%=============================================================================
 %% Internal Functions
 %%=============================================================================


### PR DESCRIPTION
Implements feature request #80. Implicitly created mock is:
- **honest**, an attempt to create an expectation for a module that is not available on a code path will fail. If a user does need one he can create it explicitly with **non_strict** option;
- **passthrow**, forwards functions that had no expectations created to the original module functions.  
