### PR TITLE
Prune deprecated attribute from module attributes.

### DIFF
--- a/src/meck_code_gen.erl
+++ b/src/meck_code_gen.erl
@@ -63,7 +63,7 @@ attributes(Mod) ->
     try
         [?attribute(Key, Val) || {Key, Val} <-
             proplists:get_value(attributes, Mod:module_info(), []),
-            Key =/= vsn]
+            Key =/= vsn, Key =/= deprecated]
     catch
         error:undef -> []
     end.


### PR DESCRIPTION
I've observed problems mocking libraries that include the `-deprecated` directive.
