### PR TITLE
Do not consider a 3-tuple return value as an exception

### DIFF
--- a/src/meck_code_gen.erl
+++ b/src/meck_code_gen.erl
@@ -180,7 +180,8 @@ handle_exception(Pid, Mod, Func, Args, Class, Reason) ->
         no_return().
 raise(Pid, Mod, Func, Args, Class, Reason) ->
     StackTrace = inject(Mod, Func, Args, erlang:get_stacktrace()),
-    meck_proc:add_history(Mod, Pid, Func, Args, {Class, Reason, StackTrace}),
+    meck_proc:add_history_exception(Mod, Pid, Func, Args,
+                                    {Class, Reason, StackTrace}),
     erlang:raise(Class, Reason, StackTrace).
 
 -spec inject(Mod::atom(), Func::atom(), Args::[any()],

--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -31,6 +31,7 @@
 
 %% To be accessible from generated modules
 -export([get_result_spec/3]).
+-export([add_history_exception/5]).
 -export([add_history/5]).
 -export([invalidate/1]).
 
@@ -117,11 +118,16 @@ set_expect(Mod, Expect) ->
 delete_expect(Mod, Func, Ari) ->
     gen_server(call, Mod, {delete_expect, Func, Ari}).
 
+-spec add_history_exception(
+        Mod::atom(), CallerPid::pid(), Func::atom(), Args::[any()],
+        {Class::error|exit|throw, Reason::any(), StackTrace::any()}) ->
+        ok.
+add_history_exception(Mod, CallerPid, Func, Args, {Class, Reason, StackTrace}) ->
+    gen_server(cast, Mod, {add_history, {CallerPid, {Mod, Func, Args}, Class, Reason, StackTrace}}).
+
 -spec add_history(Mod::atom(), CallerPid::pid(), Func::atom(), Args::[any()],
                   Result::any()) ->
         ok.
-add_history(Mod, CallerPid, Func, Args, {Class, Reason, StackTrace}) ->
-    gen_server(cast, Mod, {add_history, {CallerPid, {Mod, Func, Args}, Class, Reason, StackTrace}});
 add_history(Mod, CallerPid, Func, Args, Result) ->
     gen_server(cast, Mod, {add_history, {CallerPid, {Mod, Func, Args}, Result}}).
 

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -262,12 +262,15 @@ history_call_(Mod) ->
     ok = meck:expect(Mod, test, fun() -> ok end),
     ok = meck:expect(Mod, test2, fun(_, _) -> result end),
     ok = meck:expect(Mod, test3, 0, 3),
+    ok = meck:expect(Mod, test4, 0, {1,2,3}),
     Mod:test(),
     Mod:test2(a, b),
     Mod:test3(),
+    Mod:test4(),
     ?assertEqual([{self(), {Mod, test,  []},     ok},
                   {self(), {Mod, test2, [a, b]}, result},
-                  {self(), {Mod, test3, []},     3}], meck:history(Mod)).
+                  {self(), {Mod, test3, []},     3},
+                  {self(), {Mod, test4, []},     {1,2,3}}], meck:history(Mod)).
 
 history_throw_(Mod) ->
     ok = meck:expect(Mod, test, fun() -> throw(test_exception) end),


### PR DESCRIPTION
Use an additional parameter in meck_proc:add_history for explicitly
specifying whether the entry added in the history is supposed to be an
exception ('x') or a normal return value of a function call ('c').
