### PR TITLE
Add an option to create modules named after their PID

### DIFF
--- a/src/meck_util.erl
+++ b/src/meck_util.erl
@@ -22,6 +22,7 @@
 -export([proc_name/1]).
 -export([original_name/1]).
 -export([match_spec_item/1]).
+-export([pid_to_atom/1]).
 
 %%%============================================================================
 %%% Types
@@ -42,3 +43,7 @@ original_name(Name) -> list_to_atom(atom_to_list(Name) ++ "_meck_original").
 -spec match_spec_item(Pattern::tuple()) -> match_spec_item().
 match_spec_item(Pattern) ->
     {Pattern, [], ['$_']}.
+
+-spec pid_to_atom(pid()) -> atom().
+pid_to_atom(Pid) ->
+    list_to_atom(pid_to_list(Pid)).

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -1409,6 +1409,38 @@ wait_purge_expired_tracker_test() ->
     %% Clean
     meck:unload().
 
+spawn_pid_module_test() ->
+    %% just_a_dog and just_a_cat hold no value when using pid_module
+    Dog = meck:new(just_a_dog, [pid_module]),
+    Cat = meck:new(just_a_cat, [pid_module]),
+    meck:expect(Dog, stare_at, fun(Target) -> meck_proc:send(Target, "*Stare*") end),
+    meck:expect(Dog, bark_at,  fun(Target) -> meck_proc:send(Target, "Woof!") end),
+    meck:expect(Dog, sleep, fun() -> zzz end),
+    meck:expect(Cat, react, fun () ->
+        case meck_proc:get(Cat) of
+            "Woof!" -> run_away;
+            _       -> just_being_a_cat
+        end
+    end),
+
+    Dog:stare_at(Cat),
+    Result1 = Cat:react(),
+
+    Dog:bark_at(Cat),
+    Result2 = Cat:react(),
+    Result3 = Dog:sleep(),
+
+    Expect1 = just_being_a_cat,
+    Expect2 = run_away,
+    Expect3 = zzz,
+    meck:unload(),
+    [
+       ?assertEqual(Expect1, Result1),
+       ?assertEqual(Expect2, Result2),
+       ?assertEqual(Expect3, Result3)
+    ].
+
+
 %%=============================================================================
 %% Internal Functions
 %%=============================================================================


### PR DESCRIPTION
First of all: This feature feels like it strays from the purpose of Meck. Therefore if you don't agree with adding this feature I'll understand and will build my own library and re-implement the Meck specific characteristics that I require.

This feature adds the ability to create a new module named after its process id. Why would you want this? The PID is a unique identifier, meaning you can't spawn two of the same "new" modules. This is nice because you can create object-like variable with their own functions.


This is already possible by simply doing:

    MyObject = fun(one) -> 1; (two) -> 2 end,
    MyObject(one),  %=> 1
    MyObject(two).  %=> 2

However it's very limited,
1. You only have X amount of arguments (can't pattern match different arity)
2. You can't bind actual functions to them
3. There is no sense of state

With this change you can create new modules named after their Pid (as an atom) and bind it to a variable.
In the test there is an example of this usage.

    Dog = meck:new(just_a_dog, [pid_module]),
    Cat = meck:new(just_a_cat, [pid_module]),
    meck:expect(Dog, stare_at, fun(Target) -> meck_proc:send(Target, "*Stare*") end),
    meck:expect(Dog, bark_at,  fun(Target) -> meck_proc:send(Target, "Woof!") end),
    meck:expect(Dog, sleep, fun() -> zzz end),
    meck:expect(Cat, react, fun () ->
        case meck_proc:get(Cat) of
            "Woof!" -> run_away;
            _       -> just_being_a_cat
        end
    end),

    Dog:stare_at(Cat), %=> *send message to Cat*
    Cat:react(),       %=> just_being_a_cat
    Dog:bark_at(Cat),  %=> *send message to Cat*
    Cat:react(),       %=> run_away,
    Dog:sleep().       %=> zzz,


I don't feel that this really belongs in Meck, but Meck provides everything I need for this feature. And I can't use Meck as a dependency because I need to adjust Meck's implementation to make this work. So if you think this should not be in Meck I'll create my own library for it.