### PR TITLE
Update meck for OTP 18.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %% Compiler Options ===========================================================
 {erl_opts, [
     %% Erlang releases after 17 don't put R in front of their name, and also require dict() to be written like dict:dict()
-    {platform_define, "^[0-9]+", namespaced_dicts}, 
+    {platform_define, "^[0-9]+", namespaced_types},
     warn_export_all,
     warn_export_vars,
     warn_shadow_vars,

--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -47,7 +47,7 @@
 %%% Definitions
 %%%============================================================================
 
--ifdef(namespaced_dicts).
+-ifdef(namespaced_types).
 -type meck_dict() :: dict:dict().
 -else.
 -type meck_dict() :: dict().

--- a/test.config
+++ b/test.config
@@ -4,11 +4,11 @@
                     {branch, "master"}}}]}.
 
 %% Compiler Options ===========================================================
-% FIXME: Add warnings_as_errors once Hamcrest is fixed
 {erl_opts, [
     %% Erlang releases after 17 don't put R in front of their name, and also require dict() to be written like dict:dict()
-    {platform_define, "^[0-9]+", namespaced_dicts},
+    {platform_define, "^[0-9]+", namespaced_types},
     {platform_define, "^R(?!16B03)", cover_empty_compile_opts},
+    warnings_as_errors,
     debug_info
 ]}.
 


### PR DESCRIPTION
In order to avoid creating temporary files meck_cover needs direct
access to some unexported functions of cover.
In OTP 18.0 the internal API of cover changed a bit and
compile_beam/2 (which allows passing a binary instead just a filename)
was replaced by compile_beams/1.

See https://github.com/erlang/otp/commit/ab435488

Travis does not have OTP 18.0-rc1 yet but the unit tests pass on my machine
(with the namespaced types change)