### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ make test
 Two things might seem alarming when running the tests:
 
   1. Warnings emitted by cover
-  2. En exception printed by SASL
+  2. An exception printed by SASL
 
 Both are expected due to the way Erlang currently prints errors. The
 important line you should look for is `All XX tests passed`, if that


### PR DESCRIPTION
The string *"An exception printed by SASL"* was changed to *"En exception
printed by SASL"* ("An" => "En") during a reformatting of the text in
2011 via
https://github.com/eproxus/meck/commit/51ecfb43a7193066c51352ff52acc6b4bdb81d7c#diff-04c6e90faac2675aa89e2176d2eec7d8L39
This reverts the spelling of "an".