### PR TITLE
Fix race condition between meck:unload/1 and calls to the mocked module

### DIFF
--- a/src/meck_code_gen.erl
+++ b/src/meck_code_gen.erl
@@ -144,7 +144,7 @@ var_name(A) -> list_to_atom("A"++integer_to_list(A)).
 -spec exec(CallerPid::pid(), Mod::atom(), Func::atom(), Args::[any()]) ->
         Result::any().
 exec(Pid, Mod, Func, Args) ->
-    case meck_proc:get_result_spec(Mod, Func, Args) of
+    try meck_proc:get_result_spec(Mod, Func, Args) of
         undefined ->
             meck_proc:invalidate(Mod),
             raise(Pid, Mod, Func, Args, error, function_clause);
@@ -160,6 +160,9 @@ exec(Pid, Mod, Func, Args) ->
             after
                 erase(?CURRENT_CALL)
             end
+    catch
+        error:{not_mocked, Mod} ->
+            apply(Mod, Func, Args)
     end.
 
 -spec handle_exception(CallerPid::pid(), Mod::atom(), Func::atom(),

--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -179,7 +179,7 @@ validate(Mod) ->
 
 -spec invalidate(Mod::atom()) -> ok.
 invalidate(Mod) ->
-    gen_server(call, Mod, invalidate).
+    gen_server(cast, Mod, invalidate).
 
 -spec stop(Mod::atom()) -> ok.
 stop(Mod) ->
@@ -264,14 +264,14 @@ handle_call({wait, Times, OptFunc, ArgsMatcher, OptCallerPid, Timeout}, From,
     end;
 handle_call(reset, _From, S) ->
     {reply, ok, S#state{history = []}};
-handle_call(invalidate, _From, S) ->
-    {reply, ok, S#state{valid = false}};
 handle_call(validate, _From, S) ->
     {reply, S#state.valid, S};
 handle_call(stop, _From, S) ->
     {stop, normal, ok, S}.
 
 %% @hidden
+handle_cast(invalidate, S) ->
+    {noreply, S#state{valid = false}};
 handle_cast({add_history, HistoryRecord}, S = #state{history = undefined,
                                                      trackers = Trackers}) ->
     UpdTracker = update_trackers(HistoryRecord, Trackers),


### PR DESCRIPTION
When `meck:unload(M)` and a call to the mocked module being unloaded (e.g. `M:foo()`) happens concurrently, the call may fail with error `{not_mocked, M}` (similar to e.g. #144, although that may be a different issue).

The correct behaviour would be for `M:foo()` to either procude the mocked result or execute the original, unmocked code, but it shouldn't fail.

This could be achieved by `meck_code_gen:exec/4` catching the error thrown when `meck_proc` is down, and failing back to a regular apply into the (no longer mocked) code instead. (Turning `meck_proc:invalidate/1` into a cast from a call ensures only `meck_proc:get_result_spec/3` could fail with said error from the functions used within `meck_code_gen:exec/4`.)