### PR TITLE
FIX: optional_callbacks

### DIFF
--- a/src/meck_code_gen.erl
+++ b/src/meck_code_gen.erl
@@ -63,7 +63,7 @@ attributes(Mod) ->
     try
         [?attribute(Key, Val) || {Key, Val} <-
             proplists:get_value(attributes, Mod:module_info(), []),
-            Key =/= vsn, Key =/= deprecated]
+            Key =/= vsn, Key =/= deprecated, Key =/= optional_callbacks]
     catch
         error:undef -> []
     end.


### PR DESCRIPTION
There was a case that it cannot mock the module.
This module is defined optional callback, but it isn't export this this callback functions.

This pull request fix it, but it is not the best practice...=(
