### PR TITLE
Update 'problematic modules list'

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ problematic to mock or not possible at all:
 * `os`
 * `crypto`
 * `compile`
+* `global`
 
 Also, a meck expectation set up for a function _f_ does not apply to the module-local invocation of _f_ within the mocked module.
 Consider the following module:


### PR DESCRIPTION
'Problematic modules' list now includes global

Globally replacing the 'global' module kills the global_name_server which causes the VM to crash

`
=ERROR REPORT==== 17-Sep-2015 < the time on my machine :P >===
** Generic server global_name_server terminating 
** Last message in was {'EXIT',<0.14.0>,killed}
** When Server state == {state,true,[],[],[],[],nonode@nohost,<0.14.0>,
                               <0.15.0>,no_trace,false}
** Reason for termination == 
** {'function not exported',
       [{global,terminate,
            [{undef,
                 [{global,handle_info,
                      [{'EXIT',<0.14.0>,killed},
                       {state,true,[],[],[],[],nonode@nohost,<0.14.0>,
                           <0.15.0>,no_trace,false}],
                      []},
                  {gen_server,handle_msg,5,
                      [{file,"gen_server.erl"},{line,604}]},
                  {proc_lib,init_p_do_apply,3,
                      [{file,"proc_lib.erl"},{line,239}]}]},
             {state,true,[],[],[],[],nonode@nohost,<0.14.0>,<0.15.0>,
                 no_trace,false}],
            []},
        {gen_server,terminate,6,[{file,"gen_server.erl"},{line,719}]},
        {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,239}]}]}
`