### PR TITLE
Fix eunit compile failure on Erlang 17+ (hamcrest)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,8 @@
 %% Compiler Options ===========================================================
 {erl_opts, [
     %% Erlang releases after 17 don't put R in front of their name, and also require dict() to be written like dict:dict()
-    {platform_define, "^R", non_namespaced_types},
+    {platform_define, "^R", non_namespaced_types},  % used by meck
+    {platform_define, "^[0-9]+", namespaced_types}, % used by hamcrest
     warn_export_all,
     warn_export_vars,
     warn_shadow_vars,

--- a/test.config
+++ b/test.config
@@ -6,7 +6,8 @@
 %% Compiler Options ===========================================================
 {erl_opts, [
     %% Erlang releases after 17 don't put R in front of their name, and also require dict() to be written like dict:dict()
-    {platform_define, "^R", non_namespaced_types},
+    {platform_define, "^R", non_namespaced_types},  % used by meck
+    {platform_define, "^[0-9]+", namespaced_types}, % used by hamcrest
     {platform_define, "^R(?!16B03)", cover_empty_compile_opts},
     warnings_as_errors,
     debug_info


### PR DESCRIPTION
This fixes the error:

    make test
    ...
    ==> meck (eunit)
    ...
    meck/deps/hamcrest/include/hamcrest_internal.hrl:33: type set() undefined
    meck/deps/hamcrest/include/hamcrest_internal.hrl:34: type gb_set() undefined
    Compiling test/meck_tests.erl failed:
    ERROR: eunit failed while processing meck: rebar_abort

and finally lets eunit run (and fail, at least with Erlang 18.3), but at least travis will go one step ahead :-)