### PR TITLE
fix #88

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -34,6 +34,7 @@
 -export([sequence/4]).
 -export([loop/4]).
 -export([delete/3]).
+-export([delete/4]).
 -export([exception/2]).
 -export([passthrough/1]).
 -export([history/1]).
@@ -289,17 +290,33 @@ loop(Mod, Func, Ari, Loop) when is_list(Mod) ->
 %%
 %% Deletes the expectation for the function `Func' with the matching
 %% arity `Arity'.
+%% `Force' is a flag to delete the function even if it is passthrough.
+-spec delete(Mods, Func, Ari, Force) -> ok when
+      Mods :: Mod | [Mod],
+      Mod :: atom(),
+      Func :: atom(),
+      Ari :: byte(),
+      Force :: boolean().
+delete(Mod, Func, Ari, Force)
+  when is_atom(Mod), is_atom(Func), Ari >= 0 ->
+    meck_proc:delete_expect(Mod, Func, Ari, Force);
+delete(Mod, Func, Ari, Force) when is_list(Mod) ->
+    lists:foreach(fun(M) -> delete(M, Func, Ari, Force) end, Mod),
+    ok.
+
+%% @doc Deletes an expectation.
+%%
+%% Deletes the expectation for the function `Func' with the matching
+%% arity `Arity'.
+%% If the mock has passthrough enabled, this function restores the
+%% expectation to the original function. See {@link delete/4}.
 -spec delete(Mods, Func, Ari) -> ok when
       Mods :: Mod | [Mod],
       Mod :: atom(),
       Func :: atom(),
       Ari :: byte().
-delete(Mod, Func, Ari)
-  when is_atom(Mod), is_atom(Func), Ari >= 0 ->
-    meck_proc:delete_expect(Mod, Func, Ari);
-delete(Mod, Func, Ari) when is_list(Mod) ->
-    lists:foreach(fun(M) -> delete(M, Func, Ari) end, Mod),
-    ok.
+delete(Mod, Func, Ari) ->
+    delete(Mod, Func, Ari, false).
 
 %% @doc Throws an expected exception inside an expect fun.
 %%

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -1488,6 +1488,35 @@ wait_purge_expired_tracker_test() ->
     %% Clean
     meck:unload().
 
+
+meck_passthrough_test_() ->
+    {foreach, fun setup_passthrough/0, fun teardown/1,
+     [{with, [T]} || T <- [
+                           fun ?MODULE:delete_passthrough_/1,
+                           fun ?MODULE:delete_passthrough_force_/1
+                          ]]}.
+
+setup_passthrough() ->
+    % Uncomment to run tests with dbg:
+    % dbg:tracer(),
+    % dbg:p(all, call),
+    % dbg:tpl(meck, []),
+    ok = meck:new(meck_test_module, [passthrough, non_strict]),
+    meck_test_module.
+
+delete_passthrough_(Mod) ->
+    ok = meck:expect(Mod, c, 2, {c, d}),
+    ?assertMatch({c, d}, Mod:c(a, b)),
+    ?assertEqual(ok, meck:delete(Mod, c, 2)),
+    ?assertMatch({a, b}, Mod:c(a, b)),
+    ?assert(meck:validate(Mod)).
+
+delete_passthrough_force_(Mod) ->
+    ok = meck:expect(Mod, c, 2, ok),
+    ?assertEqual(ok, meck:delete(Mod, c, 2, true)),
+    ?assertError(undef, Mod:test(a, b)),
+    ?assert(meck:validate(Mod)).
+
 %%=============================================================================
 %% Internal Functions
 %%=============================================================================


### PR DESCRIPTION
fix #88.
Added `delete/4` which has a flag to delete a function even if the module has a `passthrough` option. Now, default `delete/3` doesn't delete a function(replace to a passthrough entry implicitly) if the module has a `passthrough` option.

Thanks.