### PR TITLE
Add `meck:result/4-5' that returns the result value of a particular function

### DIFF
--- a/test/meck_history_tests.erl
+++ b/test/meck_history_tests.erl
@@ -81,3 +81,89 @@ capture_different_args_specs_test() ->
     ?assertMatch(2008, meck:capture(first, test, foo, ['_', '_', meck:is(hamcrest_matchers:greater_than(3006))], 2)),
     %% Clean
     meck:unload().
+
+result_different_positions_test() ->
+    %% Given
+    meck:new(test, [non_strict]),
+    meck:expect(test, foo, fun(_, A, _) -> A end),
+    meck:expect(test, foo, 4, ok),
+    meck:expect(test, bar, 3, ok),
+    %% When
+    test:foo(1001, 2001, 3001, 4001),
+    test:bar(1002, 2002, 3002),
+    test:foo(1003, 2003, 3003),
+    test:bar(1004, 2004, 3004),
+    test:foo(1005, 2005, 3005),
+    test:foo(1006, 2006, 3006),
+    test:bar(1007, 2007, 3007),
+    test:foo(1008, 2008, 3008),
+    %% Then
+    ?assertMatch(2003, meck_history:result(first, '_', test, foo, ['_', '_', '_'])),
+    ?assertMatch(2008, meck_history:result(last, '_', test, foo, ['_', '_', '_'])),
+    ?assertMatch(2006, meck_history:result(3, '_', test, foo, ['_', '_', '_'])),
+    ?assertError(not_found, meck_history:result(5, '_', test, foo, ['_', '_', '_'])),
+    %% Clean
+    meck:unload().
+
+result_different_args_specs_test() ->
+    %% Given
+    meck:new(test, [non_strict]),
+    meck:expect(test, foo, fun(_, A) -> A end),
+    meck:expect(test, foo, fun(_, A, _) -> A end),
+    meck:expect(test, foo, fun(_, A, _, _) -> A end),
+    meck:expect(test, bar, 3, ok),
+    %% When
+    test:foo(1001, 2001, 3001, 4001),
+    test:bar(1002, 2002, 3002),
+    test:foo(1003, 2003, 3003),
+    test:bar(1004, 2004, 3004),
+    test:foo(1005, 2005),
+    test:foo(1006, 2006, 3006),
+    test:bar(1007, 2007, 3007),
+    test:foo(1008, 2008, 3008),
+    %% Then
+    ?assertMatch(2001, meck_history:result(first, '_', test, foo, '_')),
+    ?assertMatch(2003, meck_history:result(first, '_', test, foo, 3)),
+    ?assertMatch(2005, meck_history:result(first, '_', test, foo, ['_', '_'])),
+    ?assertMatch(2006, meck_history:result(first, '_', test, foo, [1006, '_', '_'])),
+    Matcher = meck:is(hamcrest_matchers:greater_than(3006)),
+    ?assertMatch(2008, meck_history:result(first, '_', test, foo, ['_', '_', Matcher])),
+    %% Clean
+    meck:unload().
+
+result_exception_test() ->
+    %% Given
+    meck:new(test, [non_strict]),
+    meck:expect(test, error, fun(R) -> erlang:error(R) end),
+    meck:expect(test, throw, fun(R) -> throw(R) end),
+    meck:expect(test, exit, fun(R) -> exit(R) end),
+    %% When
+    catch test:error(foo),
+    catch test:throw(bar),
+    catch test:exit(baz),
+    %% Then
+    ?assertException(error, foo, meck_history:result(first, '_', test, error, 1)),
+    ?assertException(throw, bar, meck_history:result(first, '_', test, throw, 1)),
+    ?assertException(exit, baz, meck_history:result(first, '_', test, exit, 1)),
+    ?assertError(not_found, meck_history:result(first, '_', test, foo, 0)),
+    %% Clean
+    meck:unload().
+
+result_different_caller_test() ->
+    %% Given
+    meck:new(test, [non_strict]),
+    meck:expect(test, foo, fun(_, A, _) -> A end),
+    %% When
+    test:foo(1001, 2001, 3001),
+    Self = self(),
+    Pid = spawn(fun() ->
+                        test:foo(1002, 2002, 3002),
+                        Self ! {self(), done}
+                end),
+    test:foo(1003, 2003, 3003),
+    receive {Pid, done} -> ok end,
+    %% Then
+    ?assertMatch(2003, meck_history:result(2, self(), test, foo, 3)),
+    ?assertMatch(2002, meck_history:result(last, Pid, test, foo, 3)),
+    %% Clean
+    meck:unload().


### PR DESCRIPTION
Hi! Thank you for the nice library.

I would like a function that returns the result value of a specified function, like follows.

``` erlang
-module(test).

-compile(export_all).

foo() -> a.

bar(a) -> b.
bar(_) -> c.
```

``` erlang
> Fun = fun() -> A = test:foo(), test:bar(A) end.
> Fun().
> meck:result(last, test, foo, 0). %=> a
```

I implemented `meck:result(Occur, Mod, Func, OptArgsSpec)` and `meck:result(Occur, Mod, Func, OptArgsSpec, OptCallerPid)`. What do you think about this?
