### PR TITLE
Add 19.2 to versions tested by TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ notifications:
   email:
     - hello@alind.io
 otp_release:
+  - 19.2
   - 18.3
   - 17.5
   - R16B03-1


### PR DESCRIPTION
Erlang 19 is the latest.  Want to make sure this works for the latest OTP release.