### PR TITLE
Erl19 Breaks Mecking Callbacks/Behaviour Modules

### DIFF
--- a/test/meck_behaviour_module.erl
+++ b/test/meck_behaviour_module.erl
@@ -1,0 +1,7 @@
+-module(meck_behaviour_module).
+
+-export([pong/0]).
+
+-callback ping() -> ok.
+
+pong() -> ok.

--- a/test/meck_behaviour_tests.erl
+++ b/test/meck_behaviour_tests.erl
@@ -1,0 +1,21 @@
+-module(meck_behaviour_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+mock_behaviour_module_test_() ->
+    {
+        setup,
+        fun() -> catch meck:new([meck_behaviour_module, meck_callback_module], [no_link]) end,
+        fun(_) -> meck:unload() end,
+        fun(MeckNewResult) -> { "Behaviour modules and callbacks can be mocked together",
+            ?_test(begin
+                       ?assertEqual(ok, MeckNewResult),
+
+                        meck:expect(meck_callback_module, ping, fun() -> not_ok end),
+                        meck:expect(meck_behaviour_module, pong, fun() -> this_is_new end),
+
+                        ?assertEqual(not_ok, meck_callback_module:ping()),
+                        ?assertEqual(this_is_new, meck_behaviour_module:pong())
+                   end)}
+        end
+    }.

--- a/test/meck_callback_module.erl
+++ b/test/meck_callback_module.erl
@@ -1,0 +1,6 @@
+-module(meck_callback_module).
+-behaviour(meck_behaviour_module).
+
+-export([ping/0]).
+
+ping() -> ok.


### PR DESCRIPTION
This PR adds a single test with two additional helper modules used by the test.

The test demonstrates mocking both a behavior and callback module in the same
meck:new/? call.  This test passes in erlang 18.x as expected, but when running
from erlang 19, this test fails.

The error indicates that some compiler is not seeing the mocked behavior module
as the behavior module that it is.  I don't have a definitive reason for this,
but I have strong suspicions that the reason is related to:

http://erlang.org/pipermail/erlang-questions/2016-June/089615.html
http://erlang.org/pipermail/erlang-questions/2017-January/091396.html

Basically in erlang 19 the call M:module_info() seems to have stopped returning
the list of callbacks as attributes.  My guess is that Meck is using these in
some way to create the mocked version of the behavior module.  As the email
list posts state the callbacks are still there via beam_lib and potentially other ways.  It may be possible to fix this by using beam_lib, or perhaps by using merl to examine the AST.