### PR TITLE
fix behavio(u)r attributes validation on Erlang R20

### DIFF
--- a/src/meck_code_gen.erl
+++ b/src/meck_code_gen.erl
@@ -59,11 +59,23 @@ get_current_call() ->
 %%% Internal functions
 %%%============================================================================
 
+attribute({Key, _Value}, Attrs)
+    when Key =:= vsn;
+	 Key =:= deprecated;
+	 Key =:= optional_callbacks ->
+    Attrs;
+attribute({Key, Value}, Attrs)
+  when (Key =:= behaviour orelse Key =:= behavior)
+       andalso is_list(Value) ->
+    lists:foldl(fun(Behavior, Acc) -> [?attribute(Key, Behavior) | Acc] end,
+		Attrs, Value);
+attribute({Key, Value}, Attrs) ->
+    [?attribute(Key, Value) | Attrs].
+
 attributes(Mod) ->
     try
-        [?attribute(Key, Val) || {Key, Val} <-
-            proplists:get_value(attributes, Mod:module_info(), []),
-            Key =/= vsn, Key =/= deprecated, Key =/= optional_callbacks]
+	lists:foldl(fun attribute/2, [],
+		    proplists:get_value(attributes, Mod:module_info(), []))
     catch
         error:undef -> []
     end.


### PR DESCRIPTION
R20 now checks whether behavio(u)r attribute contains a
valid module name. The attributes content was simply take
from module_info/0. However, module_info/0 contains a list
of behavior and the attribute should only contain as single
module name.

Expand the list of behavio(u)rs into a list of attrbiutes
to make erl_lint happy.

fixes #175 