### PR TITLE
Fix for Rebar 2.x.y on secondary arches

### DIFF
--- a/test/meck_history_tests.erl
+++ b/test/meck_history_tests.erl
@@ -18,9 +18,28 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-num_calls_with_arity_test() ->
+history_test_() ->
+    {foreach, fun setup/0, fun teardown/1,
+     [fun num_calls_with_arity/0,
+      fun capture_different_positions/0,
+      fun capture_different_args_specs/0,
+      fun result_different_positions/0,
+      fun result_different_args_specs/0,
+      fun result_exception/0,
+      fun result_different_caller/0
+     ]
+    }.
+
+setup() ->
     %% Given
     meck:new(test, [non_strict]),
+    ok.
+
+teardown(_) ->
+    %% Cleanup
+    meck:unload().
+
+num_calls_with_arity() ->
     meck:expect(test, foo, 2, ok),
     meck:expect(test, foo, 3, ok),
     %% When
@@ -32,13 +51,9 @@ num_calls_with_arity_test() ->
     %% Then
     ?assertMatch(2, meck:num_calls(test, foo, 2)),
     ?assertMatch(3, meck:num_calls(test, foo, 3)),
-    ?assertMatch(0, meck:num_calls(test, foo, 4)),
-    %% Clean
-    meck:unload().
+    ?assertMatch(0, meck:num_calls(test, foo, 4)).
 
-capture_different_positions_test() ->
-    %% Given
-    meck:new(test, [non_strict]),
+capture_different_positions() ->
     meck:expect(test, foo, 3, ok),
     meck:expect(test, foo, 4, ok),
     meck:expect(test, bar, 3, ok),
@@ -54,13 +69,9 @@ capture_different_positions_test() ->
     ?assertMatch(2003, meck:capture(first, test, foo, ['_', '_', '_'], 2)),
     ?assertMatch(2008, meck:capture(last, test, foo, ['_', '_', '_'], 2)),
     ?assertMatch(2006, meck:capture(3, test, foo, ['_', '_', '_'], 2)),
-    ?assertError(not_found, meck:capture(5, test, foo, ['_', '_', '_'], 2)),
-    %% Clean
-    meck:unload().
+    ?assertError(not_found, meck:capture(5, test, foo, ['_', '_', '_'], 2)).
 
-capture_different_args_specs_test() ->
-    %% Given
-    meck:new(test, [non_strict]),
+capture_different_args_specs() ->
     meck:expect(test, foo, 2, ok),
     meck:expect(test, foo, 3, ok),
     meck:expect(test, foo, 4, ok),
@@ -78,13 +89,9 @@ capture_different_args_specs_test() ->
     ?assertMatch(2003, meck:capture(first, test, foo, 3, 2)),
     ?assertMatch(2005, meck:capture(first, test, foo, ['_', '_'], 2)),
     ?assertMatch(2006, meck:capture(first, test, foo, [1006, '_', '_'], 2)),
-    ?assertMatch(2008, meck:capture(first, test, foo, ['_', '_', meck:is(fun(X) -> X > 3006 end)], 2)),
-    %% Clean
-    meck:unload().
+    ?assertMatch(2008, meck:capture(first, test, foo, ['_', '_', meck:is(fun(X) -> X > 3006 end)], 2)).
 
-result_different_positions_test() ->
-    %% Given
-    meck:new(test, [non_strict]),
+result_different_positions() ->
     meck:expect(test, foo, fun(_, A, _) -> A end),
     meck:expect(test, foo, 4, ok),
     meck:expect(test, bar, 3, ok),
@@ -101,13 +108,9 @@ result_different_positions_test() ->
     ?assertMatch(2003, meck_history:result(first, '_', test, foo, ['_', '_', '_'])),
     ?assertMatch(2008, meck_history:result(last, '_', test, foo, ['_', '_', '_'])),
     ?assertMatch(2006, meck_history:result(3, '_', test, foo, ['_', '_', '_'])),
-    ?assertError(not_found, meck_history:result(5, '_', test, foo, ['_', '_', '_'])),
-    %% Clean
-    meck:unload().
+    ?assertError(not_found, meck_history:result(5, '_', test, foo, ['_', '_', '_'])).
 
-result_different_args_specs_test() ->
-    %% Given
-    meck:new(test, [non_strict]),
+result_different_args_specs() ->
     meck:expect(test, foo, fun(_, A) -> A end),
     meck:expect(test, foo, fun(_, A, _) -> A end),
     meck:expect(test, foo, fun(_, A, _, _) -> A end),
@@ -127,13 +130,9 @@ result_different_args_specs_test() ->
     ?assertMatch(2005, meck_history:result(first, '_', test, foo, ['_', '_'])),
     ?assertMatch(2006, meck_history:result(first, '_', test, foo, [1006, '_', '_'])),
     Matcher = meck:is(fun(X) -> X > 3006 end),
-    ?assertMatch(2008, meck_history:result(first, '_', test, foo, ['_', '_', Matcher])),
-    %% Clean
-    meck:unload().
+    ?assertMatch(2008, meck_history:result(first, '_', test, foo, ['_', '_', Matcher])).
 
-result_exception_test() ->
-    %% Given
-    meck:new(test, [non_strict]),
+result_exception() ->
     meck:expect(test, error, fun(R) -> erlang:error(R) end),
     meck:expect(test, throw, fun(R) -> throw(R) end),
     meck:expect(test, exit, fun(R) -> exit(R) end),
@@ -145,13 +144,9 @@ result_exception_test() ->
     ?assertException(error, foo, meck_history:result(first, '_', test, error, 1)),
     ?assertException(throw, bar, meck_history:result(first, '_', test, throw, 1)),
     ?assertException(exit, baz, meck_history:result(first, '_', test, exit, 1)),
-    ?assertError(not_found, meck_history:result(first, '_', test, foo, 0)),
-    %% Clean
-    meck:unload().
+    ?assertError(not_found, meck_history:result(first, '_', test, foo, 0)).
 
-result_different_caller_test() ->
-    %% Given
-    meck:new(test, [non_strict]),
+result_different_caller() ->
     meck:expect(test, foo, fun(_, A, _) -> A end),
     %% When
     test:foo(1001, 2001, 3001),
@@ -164,6 +159,4 @@ result_different_caller_test() ->
     receive {Pid, done} -> ok end,
     %% Then
     ?assertMatch(2003, meck_history:result(2, self(), test, foo, 3)),
-    ?assertMatch(2002, meck_history:result(last, Pid, test, foo, 3)),
-    %% Clean
-    meck:unload().
+    ?assertMatch(2002, meck_history:result(last, Pid, test, foo, 3)).

--- a/test/meck_ret_spec_tests.erl
+++ b/test/meck_ret_spec_tests.erl
@@ -17,52 +17,51 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-passthrough_test() ->
+ret_spec_test_() ->
+    {foreach, fun setup/0, fun teardown/1,
+     [fun passthrough/0,
+      fun explicit_exec/0,
+      fun exec/0,
+      fun deep_exec/0,
+      fun invalid_arity_exec/0
+     ]
+    }.
+
+setup() ->
     %% Given
     meck:new(meck_test_module),
+    ok.
+
+teardown(_) ->
+    %% Cleanup
+    meck:unload().
+
+passthrough() ->
     %% When
     meck:expect(meck_test_module, c, 2, meck:passthrough()),
     %% Then
-    ?assertEqual({1, 3}, meck_test_module:c(1, 3)),
-    %% Cleanup
-    meck:unload().
+    ?assertEqual({1, 3}, meck_test_module:c(1, 3)).
 
-explicit_exec_test() ->
-    %% Given
-    meck:new(meck_test_module),
+explicit_exec() ->
     %% When
     meck:expect(meck_test_module, c, 2, meck:exec(fun(A, B) -> {B, A} end)),
     %% Then
-    ?assertEqual({3, 1}, meck_test_module:c(1, 3)),
-    %% Cleanup
-    meck:unload().
+    ?assertEqual({3, 1}, meck_test_module:c(1, 3)).
 
-exec_test() ->
-    %% Given
-    meck:new(meck_test_module),
+exec() ->
     %% When
     meck:expect(meck_test_module, c, 2, fun(A, B) -> {B, A} end),
     %% Then
-    ?assertEqual({3, 1}, meck_test_module:c(1, 3)),
-    %% Cleanup
-    meck:unload().
+    ?assertEqual({3, 1}, meck_test_module:c(1, 3)).
 
-deep_exec_test() ->
-    %% Given
-    meck:new(meck_test_module),
+deep_exec() ->
     %% When
     meck:expect(meck_test_module, c, 2, meck_ret_spec:seq([fun(A, B) -> {B, A} end])),
     %% Then
-    ?assertEqual({3, 1}, meck_test_module:c(1, 3)),
-    %% Cleanup
-    meck:unload().
+    ?assertEqual({3, 1}, meck_test_module:c(1, 3)).
 
-invalid_arity_exec_test() ->
-    %% Given
-    meck:new(meck_test_module),
+invalid_arity_exec() ->
     %% When
     meck:expect(meck_test_module, c, 2, meck_ret_spec:seq([fun(A, B) -> {B, A} end])),
     %% Then
-    ?assertError(undef, meck_test_module:c(1, 2, 3)),
-    %% Cleanup
-    meck:unload().
+    ?assertError(undef, meck_test_module:c(1, 2, 3)).


### PR DESCRIPTION
Erlang + Eunit + Rebar2 behaves differently on secondary arches (mips,
sh4, powerpc, and likely other BigEndian ones). Apparently we need to
specify setup and teardown procedures explicitly instead of copying
meck:new(...) followed by meck:unload() in every test of a suite. Don't
know why, but doing this won't hurt.

I cannot reproduce this issue with Rebar3.

Fixes #105.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>