### PR TITLE
Support running meck with modules built with '+deterministic' compile…

### DIFF
--- a/src/meck_code.erl
+++ b/src/meck_code.erl
@@ -123,5 +123,8 @@ load_binary(Name, Binary) ->
 % module, and often are not always available when compiling the forms, so
 % filter them out of the options
 filter_options (Options) ->
-    lists:filter(fun({parse_transform,_}) -> false; (_) -> true end, Options).
+    case Options of
+        undefined -> [];
+        _ -> lists:filter(fun({parse_transform,_}) -> false; (_) -> true end, Options)
+    end.
 


### PR DESCRIPTION
… option

When modules are built with '+deterministic' option, the BEAM files
don't have compile options available in the module_info/1:

    $ cat foo.erl
    -module(foo).
    $ erlc foo.erl
    $ erl -noshell -eval 'io:format("~p~n", [foo:module_info(compile)])' -run init stop
    [{options,[]},
    {version,"7.1.1"},
    {source,"/home/foobar/foo.erl"}]
    $ rm foo.beam
    $ erlc +deterministic foo.erl
    $ erl -noshell -eval 'io:format("~p~n", [foo:module_info(compile)])' -run init stop
    [{version,"7.1.1"}]

Running meck against these modules fail:

    ::{function_clause,[{lists,'-filter/2-lc$^0/1-0-',
                               [undefined],
                               [{file,"lists.erl"},{line,1286}]},
                        {meck_proc,backup_original,3,
                                   [{file,"/home/foobar/meck/_build/default/lib/meck/src/meck_proc.erl"},
                                    {line,361}]},
                        {meck_proc,init,1,
                                   [{file,"/home/foobar/meck/_build/default/lib/meck/src/meck_proc.erl"},
                                    {line,206}]},
                        {gen_server,init_it,2,
                                    [{file,"gen_server.erl"},{line,365}]},
                        {gen_server,init_it,6,[{file,[...]},{line,...}]},
                        {proc_lib,init_p_do_apply,3,[{file,...},{...}]}]}

This commit fixes the problem.

Fixes https://github.com/eproxus/meck/issues/184