### PR TITLE
deprecated erlang:get_stacktrace/0 function

### DIFF
--- a/include/meck.hrl
+++ b/include/meck.hrl
@@ -1,0 +1,7 @@
+-ifdef(OTP_RELEASE).
+-define(GET_STACKTRACE, []).
+-define(WITH_STACKTRACE(T, R, S), T:R:S ->).
+-else.
+-define(GET_STACKTRACE, erlang:get_stacktrace()).
+-define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(),).
+-endif.

--- a/rebar.config
+++ b/rebar.config
@@ -26,3 +26,9 @@
         ]}
     ]}
 ]}.
+
+{edoc_opts,
+	[
+	{preprocess, true}
+	]
+}.

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -16,6 +16,8 @@
 
 -module(meck_tests).
 
+-include("meck.hrl").
+
 -include_lib("eunit/include/eunit.hrl").
 
 -define(assertTerminated(MonitorRef, Reason, Timeout),
@@ -207,11 +209,11 @@ stacktrace_(Mod) ->
         Mod:test(),
         throw(failed)
     catch
-        error:test_error ->
+        ?WITH_STACKTRACE(error, test_error, Stacktrace)
             ?assert(lists:any(fun({M, test, []}) when M == Mod    -> true;
                                  ({M, test, [],[]}) when M == Mod -> true;
                                  (_)                              -> false
-                              end, erlang:get_stacktrace()))
+                              end, Stacktrace))
     end.
 
 stacktrace_function_clause_(Mod) ->
@@ -220,8 +222,7 @@ stacktrace_function_clause_(Mod) ->
         Mod:test(error),
         throw(failed)
     catch
-        error:function_clause ->
-            Stacktrace = erlang:get_stacktrace(),
+        ?WITH_STACKTRACE(error, function_clause, Stacktrace)
             ?assert(lists:any(
                 fun ({M, test, [error]}) when M == Mod     -> true;
                     ({M, test, [error], []}) when M == Mod -> true;


### PR DESCRIPTION
Besides, a new tag is needed to push to hex.pm