### PR TITLE
Fix include directives inclusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ otp_release:
   - 19.3
   - 18.3
   - 17.5
-  - R16B03-1
-  - R15B03
 
 script: rebar3 eunit
 install:

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -1067,7 +1067,7 @@ cover_options_fail_({_OldPath, Src, Module}) ->
         proplists:delete(outdir, lists:sort(meck_code:compile_options(Module)))
     ),
     {ok, _} = cover:compile_beam(Module),
-    ?assertEqual(?compile_options, meck_code:compile_options(Module)),
+    ?assertEqual(?compile_options, proplists:delete(outdir, lists:sort(CompilerOptions))),
     a      = Module:a(),
     b      = Module:b(),
     {1, 2} = Module:c(1, 2),

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -1044,6 +1044,7 @@ cover_options_({_OldPath, Src, Module}) ->
 -define(compile_options, []).
 -else.
 -define(compile_options, [
+    debug_info,
     {i, test_include()},
     {d, 'TEST', true}
 ]).


### PR DESCRIPTION
Hello!
I think I've found something really awful.

Surprisingly but compiler_opts from BEAM-file doesn't contain include
directives (at least on some Erlang versions). So we have to try read
debug_info contents as well and merge these two.

Unfortunately this means that we cannot rely on output of
Module:module_info(compile). Instead we need to find a binary BeamFile
and parse it with beam_lib.

The result of this missing include is that meck fails to recompile and
restore original file (it cannot compile becausxe includes are missing).
Unfortunately it doesn't tell us anything reasonable about the problem
occured. 

This fixes strange and cryptic errors like:

```
    meck_tests: cover_options_test_...*skipped*
    undefined
    *unexpected termination of test process*
::{{badmatch,{error,"/home/petro/work/meck/.eunit/../test/cover_test_module.erl"}},
   [{meck_proc,restore_original,4,[{file,"src/meck_proc.erl"},{line,558}]},
    {meck_proc,terminate,2,[{file,"src/meck_proc.erl"},{line,330}]},
    {gen_server,try_terminate,3,[{file,"gen_server.erl"},{line,648}]},
    {gen_server,terminate,10,[{file,"gen_server.erl"},{line,833}]},
    {gen_server,handle_msg,6,[{file,[...]},{line,...}]},
    {proc_lib,init_p_do_apply,3,[{file,...},{...}]}]}

=ERROR REPORT==== 17-Sep-2018::15:17:58 ===
** Generic server cover_test_module_meck terminating
** Last message in was stop
** When Server state == {state,cover_test_module,
                         [{a,0},{b,0},{c,2}],
                         {dict,1,16,16,8,80,48,
                          {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
                          {{[],[],[],
                            [[{a,0}|
                              {{a,0},
                               [{{args_matcher,[],
                                  #Ref<0.3664874906.3086876677.41258>,false},
                                 {meck_exec,
                                  #Fun<meck_tests.383.64411938>}}]}]],
                            [],[],[],[],[],[],[],[],[],[],[],[]}}},
                         true,
                         [{<0.936.0>,{cover_test_module,a,[]},c}],
                         {{"/home/petro/work/meck/.eunit/../test/cover_test_module.erl",
                           "/home/petro/work/meck/.eunit/cover_test_module.coverdata",
                           [{d,'TEST',true}]},
                          no_binary},
                         false,false,false,undefined,[]}
** Reason for termination ==
** {{badmatch,{error,"/home/petro/work/meck/.eunit/../test/cover_test_module.erl"}},
    [{meck_proc,restore_original,4,[{file,"src/meck_proc.erl"},{line,558}]},
     {meck_proc,terminate,2,[{file,"src/meck_proc.erl"},{line,330}]},
     {gen_server,try_terminate,3,[{file,"gen_server.erl"},{line,648}]},
     {gen_server,terminate,10,[{file,"gen_server.erl"},{line,833}]},
     {gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,679}]},
     {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
** Client <0.936.0> stacktrace
** [{gen,do_call,4,[{file,"gen.erl"},{line,169}]},
    {gen_server,call,2,[{file,"gen_server.erl"},{line,202}]},
    {meck_proc,gen_server,3,[{file,"src/meck_proc.erl"},{line,470}]},
    {meck,unload,1,[{file,"src/meck.erl"},{line,475}]},
    {meck_tests,run_mock_no_cover_file,1,
                [{file,"test/meck_tests.erl"},{line,1094}]},
    {meck_tests,cover_options_,1,[{file,"test/meck_tests.erl"},{line,1039}]},
    {eunit_test,run_testfun,1,[{file,"eunit_test.erl"},{line,71}]},
    {eunit_proc,run_test,1,[{file,"eunit_proc.erl"},{line,510}]}]
  meck_tests: cover_options_test_...*failed*
in function meck_tests:'-cover_options_fail_/1-fun-0-'/2 (test/meck_tests.erl, line 1066)
in call from meck_tests:cover_options_fail_/1 (test/meck_tests.erl, line 1064)
**error:{assertEqual,[{module,meck_tests},
              {line,1066},
              {expression,"proplists : delete ( outdir , lists : sort ( meck_code : compile_options ( Module ) ) )"},
              {expected,[debug_info,{i,"../test/include"},{d,'TEST',true}]},
              {value,[debug_info,{d,'TEST',true}]}]}
  output:<<"">>
```

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>