### PR TITLE
Use old rebar3 3.5.0 on travis for OTP R15/R16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ otp_release:
 
 script: rebar3 eunit
 install:
-  - wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
+  - case $TRAVIS_OTP_RELEASE in R*) wget https://github.com/erlang/rebar3/releases/download/3.5.0/rebar3 ;; *) wget https://s3.amazonaws.com/rebar3/rebar3; esac && chmod +x rebar3
 script:
   - ./rebar3 as prod compile
   # - ./rebar3 as check xref


### PR DESCRIPTION
New rebar3 versions are compiled with OTP 17 and not compatible with
these old Erlang versions.

I think these old Erlang versions are still used out there, and it is valuable that meck still supports them. (I used R16 until very recently) So I think it makes sense to still support and test them until maintenance burden becomes too big.