### PR TITLE
Isolate backup *.coverdata from other beam instances

### DIFF
--- a/src/meck_cover.erl
+++ b/src/meck_cover.erl
@@ -39,12 +39,13 @@ rename_module(File, Name) ->
     ok.
 
 %% @doc Dump cover data for `Mod' into a .coverdata file in the current
-%% directory. Return the absolute file name.
+%% directory. Return the absolute path to the backup file.
 dump_coverdata(Mod) ->
     {ok, CWD} = file:get_cwd(),
-    File = filename:join(CWD, atom_to_list(Mod) ++ ".coverdata"),
-    ok = cover:export(File, Mod),
-    File.
+    File = lists:concat([Mod, ".", os:getpid(), ".coverdata"]),
+    Path = filename:join(CWD, File),
+    ok = cover:export(Path, Mod),
+    Path.
 
 %%=============================================================================
 %% Internal functions


### PR DESCRIPTION
If multiple beam instances are launched in parallel with the same current
working directory, it is possible for the backup cover data from one
instance to be squashed and deleted by other instances. By adding the OS
pid of beam.smp itself to the filename, we avoid this potential issue.