### PR TITLE
 Validate the options being passed to meck:new

### DIFF
--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -204,6 +204,8 @@ validate_options([enable_on_load|Options]) -> validate_options(Options);
 validate_options([passthrough|Options]) -> validate_options(Options);
 validate_options([no_history|Options]) -> validate_options(Options);
 validate_options([non_strict|Options]) -> validate_options(Options);
+validate_options([stub_all|Options]) -> validate_options(Options);
+validate_options([{stub_all, _}|Options]) -> validate_options(Options);
 validate_options([UnknownOption|_]) -> erlang:error({bad_arg, UnknownOption}).
 
 %% @hidden

--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -194,7 +194,21 @@ stop(Mod) ->
 %%%============================================================================
 
 %% @hidden
+validate_options([]) -> ok;
+validate_options([no_link|Options]) -> validate_options(Options);
+validate_options([spawn_opt|Options]) -> validate_options(Options);
+validate_options([unstick|Options]) -> validate_options(Options);
+validate_options([no_passthrough_cover|Options]) -> validate_options(Options);
+validate_options([merge_expects|Options]) -> validate_options(Options);
+validate_options([enable_on_load|Options]) -> validate_options(Options);
+validate_options([passthrough|Options]) -> validate_options(Options);
+validate_options([no_history|Options]) -> validate_options(Options);
+validate_options([non_strict|Options]) -> validate_options(Options);
+validate_options([UnknownOption|_]) -> erlang:error({bad_arg, UnknownOption}).
+
+%% @hidden
 init([Mod, Options]) ->
+    validate_options(Options),
     Exports = normal_exports(Mod),
     WasSticky = case proplists:get_bool(unstick, Options) of
         true -> {module, Mod} = code:ensure_loaded(Mod),

--- a/test/meck_history_tests.erl
+++ b/test/meck_history_tests.erl
@@ -163,7 +163,7 @@ result_different_caller() ->
 
 history_kept_while_reloading() ->
     NumCalls = 10,
-    meck:new(historical, [non_strict, passtrough]),
+    meck:new(historical, [non_strict, passthrough]),
     meck:expect(historical, test_fn, fun(Arg) -> {mocked, Arg} end),
     Test = self(),
     Caller = spawn(fun() ->

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -811,6 +811,15 @@ expect_ret_specs_(Mod) ->
 
 %% --- Tests with own setup ----------------------------------------------------
 
+validate_options_test() ->
+    Mod = validate_options,
+    try
+        meck:new(Mod, passthrought),
+        throw(failed)
+    catch
+        error:function_clause -> ok
+    end.
+
 merge_expects_module_test() ->
     Mod = merge_mod,
     meck:new(Mod, [non_strict, merge_expects]),


### PR DESCRIPTION
Right now, the options being passed to meck are not checked against a list of possible options. This bit me because I made a typo when trying to pass `passthrough` to `meck:new`. Funnily enough, by implementing the change, I found a typo in one of your test cases for that option as well.

I'm fairly new to Erlang so I'm not sure if I did everything correctly.