### PR TITLE
Add compact format status for termination

### DIFF
--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -43,6 +43,7 @@
 -export([handle_info/2]).
 -export([terminate/2]).
 -export([code_change/3]).
+-export([format_status/2]).
 
 %%%============================================================================
 %%% Definitions
@@ -344,6 +345,15 @@ terminate(_Reason, #state{mod = Mod, original = OriginalState,
 
 %% @hidden
 code_change(_OldVsn, S, _Extra) -> {ok, S}.
+
+%% @hidden
+format_status(normal, [_Pdict, State]) -> State;
+format_status(terminate, [_Pdict, State]) ->
+  #{
+    mod         => State#state.mod,
+    passthrough => State#state.passthrough,
+    original    => State#state.original
+  }.
 
 %%%============================================================================
 %%% Internal functions


### PR DESCRIPTION
Hi, the idea of this PR is basically to reduce the trace output in case of error in the mocked code. Currently it prints out all the functions and match clauses which can take a few screens for big modules :)

Ideally I would print only names of mocked functions but couldn't find an easy way to do it. Anyway feel free to adjust to whatever format makes more sense.