### PR TITLE
Do not attempt to generate dependencies when mocking

### DIFF
--- a/src/meck_code.erl
+++ b/src/meck_code.erl
@@ -121,7 +121,7 @@ load_binary(Name, Binary) ->
 
 % parse transforms have already been applied to the abstract code in the
 % module, and often are not always available when compiling the forms, so
-% filter them out of the options
+% filter them out of the options.
 %
 % Furthermore, since Erlang/OTP 20, a code may be compiled from core but
 % still have abstract code, so we make sure to remove the from_core option

--- a/src/meck_code.erl
+++ b/src/meck_code.erl
@@ -122,9 +122,15 @@ load_binary(Name, Binary) ->
 % parse transforms have already been applied to the abstract code in the
 % module, and often are not always available when compiling the forms, so
 % filter them out of the options
+%
+% The -MMD option (makedep_side_effect) needs to be removed, otherwise
+% the compiler will attempt to generate a dependency file.
 filter_options (Options) ->
     case Options of
         undefined -> [];
-        _ -> lists:filter(fun({parse_transform,_}) -> false; (_) -> true end, Options)
+        _ -> lists:filter(
+               fun({parse_transform,_}) -> false;
+                  (makedep_side_effect)  -> false;
+                  (_)                    -> true
+               end, Options)
     end.
-


### PR DESCRIPTION
The erlc option `-MMD` will cause the compiler to generate dependencies as a side-effect. This also puts `makedep_side_effect` into the beam file, causing Meck to use it when recompiling. This causes (or may cause) the mocking to fail if e.g. the destination directory specified by `{makedep_output, ...}` is not found.