### PR TITLE
Added compiler application to app.src file.

### DIFF
--- a/src/meck.app.src
+++ b/src/meck.app.src
@@ -3,7 +3,7 @@
     {vsn, "0.8.13"},
     {modules, []},
     {registered, []},
-    {applications, [kernel, stdlib, tools]},
+    {applications, [kernel, stdlib, tools, compiler]},
     {env, []},
 
     % Hex.pm


### PR DESCRIPTION
I'm using meck as part of a test release using rebar3. I am receiving a `compile:forms/2 undefined` error [here](https://github.com/eproxus/meck/blob/master/src/meck_code.erl#L71).

This line is leveraging the erts compiler application. Since the app is not included in the app.src file, it won't be copied during the release process.