### PR TITLE
Ensure gen_server calls don't timeout

### DIFF
--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -103,13 +103,14 @@ get_result_spec(Mod, Func, Args) ->
 set_expect(Mod, Expect) ->
     Proc = meck_util:proc_name(Mod),
     try
-        gen_server:call(Proc, {set_expect, Expect})
+        gen_server:call(Proc, {set_expect, Expect}, infinity)
     catch
         exit:{noproc, _Details} ->
             Options = [Mod, [passthrough]],
             case gen_server:start({local, Proc}, ?MODULE, Options, []) of
                 {ok, Pid} ->
-                    Result = gen_server:call(Proc, {set_expect, Expect}),
+                    Result = gen_server:call(Proc, {set_expect, Expect},
+                                             infinity),
                     true = erlang:link(Pid),
                     Result;
                 {error, {{undefined_module, Mod}, _StackTrace}} ->


### PR DESCRIPTION
The likelihood of hitting this problem is very low.
However, as described here http://erlang.org/pipermail/erlang-questions/2010-August/052636.html
the only real usage should be with `infinity` nowadays.
The code was also not handling the case where it timed out.