### PR TITLE
Make ret_spec/0 transparent

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -118,9 +118,9 @@
 %% Opaque data structure that specifies a value or a set of values to be returned
 %% by a mock stub function defined by either {@link expect/3} and {@link expect/4}.
 %% Values of `ret_spec()' are constructed by {@link seq/1}, {@link loop/1},
-%% {@link val/1}, and {@link raise/2} functions. They are used to specify
-%% return values in {@link expect/3} and {@link expect/4} functions, and also
-%% as a parameter of the `stub_all' option of {@link new/2} function.
+%% {@link val/1}, {@link exec/1}, and {@link raise/2} functions. They are used
+%% to specify return values in {@link expect/3} and {@link expect/4} functions,
+%% and also as a parameter of the `stub_all' option of {@link new/2} function.
 %%
 %% Note that any Erlang term `X' is a valid `ret_spec()' equivalent to
 %% `meck:val(X)'.

--- a/src/meck.erl
+++ b/src/meck.erl
@@ -114,7 +114,7 @@
 %% a pattern based argument specification that consists solely of wildcards,
 %% and has the length of arity (e.g.: 3 is equivalent to ['_', '_', '_']).
 
--opaque ret_spec() :: meck_ret_spec:ret_spec().
+-type ret_spec() :: meck_ret_spec:ret_spec().
 %% Opaque data structure that specifies a value or a set of values to be returned
 %% by a mock stub function defined by either {@link expect/3} and {@link expect/4}.
 %% Values of `ret_spec()' are constructed by {@link seq/1}, {@link loop/1},


### PR DESCRIPTION
This is necessary to allow the "any term is a valid ret_spec" usage pattern.
