### PR TITLE
Fix some static analysis issues (xref + dialyzer)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,14 +18,10 @@
 ]}.
 {xref_checks, [
     undefined_function_calls,
-    locals_not_used,
     deprecated_function_calls
 ]}.
 {dialyzer, [
     {warnings, [
-        unknown,
-        unmatched_returns,
-        error_handling,
-        underspecs
+        unknown
     ]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -16,3 +16,16 @@
         ]}
     ]}
 ]}.
+{xref_checks, [
+    undefined_function_calls,
+    locals_not_used,
+    deprecated_function_calls
+]}.
+{dialyzer, [
+    {warnings, [
+        unknown,
+        unmatched_returns,
+        error_handling,
+        underspecs
+    ]}
+]}.

--- a/src/meck_code_gen.erl
+++ b/src/meck_code_gen.erl
@@ -189,7 +189,7 @@ eval(Pid, Mod, Func, Args, ResultSpec) ->
 -spec handle_exception(CallerPid::pid(), Mod::atom(), Func::atom(),
                        Args::[any()], Class:: exit | error | throw,
                        Reason::any(),
-                       Stack::list()) ->
+                       Stack::meck_history:stack_trace()) ->
         no_return().
 handle_exception(Pid, Mod, Func, Args, Class, Reason, Stack) ->
     case meck_ret_spec:is_meck_exception(Reason) of
@@ -201,7 +201,7 @@ handle_exception(Pid, Mod, Func, Args, Class, Reason, Stack) ->
     end.
 
 -spec raise(CallerPid::pid(), Mod::atom(), Func::atom(), Args::[any()],
-            Class:: exit | error | throw, Reason::any(), Stack::list()) ->
+            Class:: exit | error | throw, Reason::any(), Stack::meck_history:stack_trace()) ->
         no_return().
 raise(Pid, Mod, Func, Args, Class, Reason, Stack) ->
     StackTrace = inject(Mod, Func, Args, Stack),
@@ -209,6 +209,7 @@ raise(Pid, Mod, Func, Args, Class, Reason, Stack) ->
                                     {Class, Reason, StackTrace}),
     erlang:raise(Class, Reason, StackTrace).
 
+-dialyzer({no_match, inject/4}). % for meck_history:stack_trace in older Erlang/OTP versions
 -spec inject(Mod::atom(), Func::atom(), Args::[any()],
              meck_history:stack_trace()) ->
         NewStackTrace::meck_history:stack_trace().

--- a/src/meck_cover.erl
+++ b/src/meck_cover.erl
@@ -22,6 +22,11 @@
 -export([rename_module/2]).
 -export([dump_coverdata/1]).
 
+-ignore_xref({cover, compile_beams, 1}).
+-ignore_xref({cover, compile_beam, 2}).
+-ignore_xref({cover, get_term, 1}).
+-ignore_xref({cover, write, 2}).
+
 %%=============================================================================
 %% Interface exports
 %%=============================================================================

--- a/src/meck_cover.erl
+++ b/src/meck_cover.erl
@@ -69,6 +69,7 @@ dump_coverdata(Mod) ->
 %% access to `compile_beam/2' which allows passing a binary.
 %% In OTP 18.0 the internal API of cover changed a bit and
 %% compile_beam/2 was replaced by compile_beams/1.
+-dialyzer({no_missing_calls, alter_cover/0}). % for cover:compile_beams/1
 alter_cover() ->
     CoverExports = cover:module_info(exports),
     case {lists:member({compile_beams,1}, CoverExports),
@@ -96,6 +97,7 @@ alter_cover() ->
     end.
 
 %% wrap cover's pre-18.0 internal API to simulate the new API
+-dialyzer({no_missing_calls, compile_beam_wrapper/1}). % for cover:compile_beam/2
 compile_beam_wrapper(ModFiles) ->
     [cover:compile_beam(Mod, Bin)||{Mod, Bin} <- ModFiles].
 
@@ -129,6 +131,7 @@ read_cover_file(File) ->
     ok = file:close(Fd),
     Terms.
 
+-dialyzer({no_missing_calls, get_terms/2}). % for cover:get_term/1
 get_terms(Fd, Terms) ->
     case cover:get_term(Fd) of
         eof -> Terms;
@@ -140,5 +143,6 @@ write_terms(File, Terms) ->
     lists:foreach(write_term(Fd), Terms),
     ok.
 
+-dialyzer({no_missing_calls, write_term/1}). % for cover:write/2
 write_term(Fd) ->
     fun(Term) -> cover:write(Term, Fd) end.

--- a/src/meck_expect.erl
+++ b/src/meck_expect.erl
@@ -39,7 +39,7 @@
                         meck_ret_spec:ret_spec()}.
 
 -type func_ari() :: {Func::atom(), Ari::byte()}.
--opaque expect() :: {func_ari(), [func_clause()]}.
+-type expect() :: {func_ari(), [func_clause()]}.
 
 %%%============================================================================
 %%% API

--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -122,7 +122,7 @@ delete_expect(Mod, Func, Ari, Force) ->
     gen_server(call, Mod, {delete_expect, Func, Ari, Force}).
 
 -spec list_expects(Mod::atom(), ExcludePassthrough::boolean()) ->
-    [{Mod::atom(), Func::atom(), Ari::byte}].
+    [{Mod::atom(), Func::atom(), Ari::byte()}].
 list_expects(Mod, ExcludePassthrough) ->
     gen_server(call, Mod, {list_expects, ExcludePassthrough}).
 


### PR DESCRIPTION
[Fix #218]

It started with me wanting to get rid of `hamcrest` -related warnings, since it's "used" but not imported by `meck`. And I write "used" because there is code to make sure it's there, before it's being used (and even `catch` clauses, at times), but the `dialyzer` doesn't care about that and complains in any way.

I guess I'll have to import `hamcrest` in the `deps` profile (on my lib.) just to force a correct analysis.

Though I did not get rid of all the warnings I wanted to get rid of, I still ended up doing a bit of clean-up, which you might want to merge.
