### PR TITLE
Isolate hamcrest

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -20,5 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: rebar3 compile
         name: Compile
+      - run: rebar3 do xref, dialyzer
+        name: Check
       - run: rebar3 do eunit, ct
         name: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script: rebar3 eunit
 install:
   - wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
 script:
-  - ./rebar3 compile
+  - ./rebar3 as prod compile
   - ./rebar3 xref
   - ./rebar3 dialyzer
   - ./rebar3 eunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: erlang
 sudo: false
 os: linux
 otp_release:
-  - 21.2
+  - 23.0
+  - 22.3
+  - 21.3
   - 20.3
   - 19.3
   - 18.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ script: rebar3 eunit
 install:
   - wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
 script:
-  - ./rebar3 as prod compile
-  # - ./rebar3 as check xref
-  # - ./rebar3 as check dialyzer
+  - ./rebar3 compile
+  - ./rebar3 xref
+  - ./rebar3 dialyzer
   - ./rebar3 eunit
   - ./rebar3 edoc
 

--- a/rebar.config
+++ b/rebar.config
@@ -17,11 +17,14 @@
     ]}
 ]}.
 {xref_checks, [
+    locals_not_used,
     undefined_function_calls,
     deprecated_function_calls
 ]}.
 {dialyzer, [
     {warnings, [
-        unknown
+        unknown,
+        unmatched_returns,
+        error_handling
     ]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
         {cover_enabled, true},
         {cover_opts, [verbose]}
     ]},
-    {compile, [
+    {prod, [
         {erl_opts, [
             debug_info,
             warnings_as_errors,

--- a/src/meck.erl
+++ b/src/meck.erl
@@ -679,7 +679,7 @@ exec(Fun) -> meck_ret_spec:exec(Fun).
 -spec is(MatcherImpl) -> matcher() when
       MatcherImpl :: Predicate | HamcrestMatcher,
       Predicate :: fun((any()) -> any()),
-      HamcrestMatcher :: hamcrest:matchspec().
+      HamcrestMatcher :: meck_matcher:hamcrest_matchspec().
 is(MatcherImpl) ->
     meck_matcher:new(MatcherImpl).
 

--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -406,7 +406,7 @@ backup_original(Mod, Passthrough, NoPassCover, EnableOnLoad) ->
             (Cover == false) orelse NoPassCover ->
                 no_passthrough_cover;
             true ->
-                meck_cover:compile_beam(NewName, Binary),
+                _ = meck_cover:compile_beam(NewName, Binary),
                 Binary
         end,
         {Cover, Binary2}


### PR DESCRIPTION
I started this after discussing [this](https://github.com/eproxus/meck/pull/219#issuecomment-729689472) and [that](https://github.com/eproxus/meck/pull/219#issuecomment-730000194), as a means to isolate `hamcrest`.

I ended up:
* isolating `hamcrest` from `dialyzer` -related static analysis issues,
* making for a stricter static analysis,
* broadening the OTP version scope and analysis scope of Travis CI.