### PR TITLE
Prevent meck_procs timeouts when stopping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Leave module loaded state as it was [\#228](https://github.com/eproxus/meck/pull/228)
 
+### Fixed
+
+- Fix misleading not_mocked errors when when unloading a mock [\#231](https://github.com/eproxus/meck/pull/231)
+
 ## [0.9.2] - 2021-03-06
 
 ### Fixed


### PR DESCRIPTION
When stopping (e.g. due to meck:unload/1), meck_procs restore the original module, which may be a time consuming operation.
If a gen_server:call is used for stopping, there's risk of a timeout that will be translated to a confusing error:{not_mocked}.
Using gen_server:stop/1 easily uses an infinity timeout, preventing the issue.

This is fixing a bug where such a time-consuming restoration was causing an end_per_suite operation to fail, confusingly.