### PR TITLE
Fix calling mocked modules from expectation fun.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Fixed
 
 - Fix misleading not_mocked errors when when unloading a mock [\#231](https://github.com/eproxus/meck/pull/231)
+- Fix calling mocked modules from expectations fun [\#232](https://github.com/eproxus/meck/pull/232)
 
 ### Removed
 

--- a/src/meck_code_gen.erl
+++ b/src/meck_code_gen.erl
@@ -173,6 +173,7 @@ exec(Pid, Mod, Func, Args) ->
 -spec eval(Pid::pid(), Mod::atom(), Func::atom(), Args::[any()],
            ResultSpec::any()) -> Result::any() | no_return().
 eval(Pid, Mod, Func, Args, ResultSpec) ->
+    PreviousCall = get(?CURRENT_CALL),
     put(?CURRENT_CALL, {Mod, Func}),
     try
         Result = meck_ret_spec:eval_result(Mod, Func, Args, ResultSpec),
@@ -183,7 +184,7 @@ eval(Pid, Mod, Func, Args, ResultSpec) ->
             handle_exception(Pid, Mod, Func, Args,
                              Class, Reason, ?_get_stacktrace_(StackToken))
     after
-        erase(?CURRENT_CALL)
+        put(?CURRENT_CALL, PreviousCall)
     end.
 
 -spec handle_exception(CallerPid::pid(), Mod::atom(), Func::atom(),

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -1376,6 +1376,12 @@ can_mock_sticky_modules_test() ->
     ?assert(code:is_sticky(meck_test_module)),
     code:unstick_mod(meck_test_module).
 
+meck_reentrant_test() ->
+    meck:new(string, [unstick, passthrough]),
+    meck:expect(string, strip, 
+        fun(String) -> meck:passthrough([string:reverse(String)]) end),
+    ?assertEqual(string:strip("  ABC  "), "CBA"),
+    meck:unload(string).
 
 sticky_directory_test_() ->
     {foreach, fun sticky_setup/0, fun sticky_teardown/1,


### PR DESCRIPTION
Before this change calling a mocked module from inside
an expectation fun, and then calling meck:passthrough/1
raises an exception. This happens because the current
call state is invalidated by the mocked function.