### PR TITLE
Make it possible to mock meck and use meck:passthrough/1

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -384,8 +384,12 @@ exception(Class, Reason) when Class == throw; Class == error; Class == exit ->
       Args :: [any()],
       Result :: any().
 passthrough(Args) when is_list(Args) ->
-    {Mod, Func} = meck_code_gen:get_current_call(),
-    erlang:apply(meck_util:original_name(Mod), Func, Args).
+    {Mod, Func} = meck_code_gen:pop_current_call(),
+    try 
+        erlang:apply(meck_util:original_name(Mod), Func, Args)
+    after 
+        meck_code_gen:push_current_call({Mod, Func})
+    end.
 
 %% @doc Validate the state of the mock module(s).
 %%

--- a/src/meck_code_gen.erl
+++ b/src/meck_code_gen.erl
@@ -173,6 +173,7 @@ exec(Pid, Mod, Func, Args) ->
 -spec eval(Pid::pid(), Mod::atom(), Func::atom(), Args::[any()],
            ResultSpec::any()) -> Result::any() | no_return().
 eval(Pid, Mod, Func, Args, ResultSpec) ->
+    PreviousCall = get(?CURRENT_CALL),
     put(?CURRENT_CALL, {Mod, Func}),
     try
         Result = meck_ret_spec:eval_result(Mod, Func, Args, ResultSpec),
@@ -183,7 +184,7 @@ eval(Pid, Mod, Func, Args, ResultSpec) ->
             handle_exception(Pid, Mod, Func, Args,
                              Class, Reason, ?_get_stacktrace_(StackToken))
     after
-        erase(?CURRENT_CALL)
+        put(?CURRENT_CALL, PreviousCall)
     end.
 
 -spec handle_exception(CallerPid::pid(), Mod::atom(), Func::atom(),

--- a/src/meck_ret_spec.erl
+++ b/src/meck_ret_spec.erl
@@ -92,7 +92,12 @@ eval_result(_Mod, _Func, Args, {meck_exec, Fun}) when is_function(Fun) ->
 eval_result(_Mod, _Func, _Args, MockedEx = {meck_raise, _Class, _Reason}) ->
     erlang:throw(MockedEx);
 eval_result(Mod, Func, Args, meck_passthrough) ->
-    erlang:apply(meck_util:original_name(Mod), Func, Args).
+    {Mod, Func} = meck_code_gen:pop_current_call(), 
+    try 
+        erlang:apply(meck_util:original_name(Mod), Func, Args)
+    after
+        meck_code_gen:push_current_call({Mod, Func})
+    end.
 
 %%%============================================================================
 %%% Internal functions

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -1376,6 +1376,12 @@ can_mock_sticky_modules_test() ->
     ?assert(code:is_sticky(meck_test_module)),
     code:unstick_mod(meck_test_module).
 
+meck_reentrant_test() ->
+    meck:new(string, [unstick, passthrough]),
+    meck:expect(string, strip, 
+        fun(String) -> meck:passthrough([string:reverse(String)]) end),
+    ?assertEqual(string:strip("  ABC  "), "CBA"),
+    meck:unload(string).
 
 sticky_directory_test_() ->
     {foreach, fun sticky_setup/0, fun sticky_teardown/1,

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -1376,12 +1376,23 @@ can_mock_sticky_modules_test() ->
     ?assert(code:is_sticky(meck_test_module)),
     code:unstick_mod(meck_test_module).
 
-meck_reentrant_test() ->
+reentrant_test() ->
     meck:new(string, [unstick, passthrough]),
     meck:expect(string, strip, 
         fun(String) -> meck:passthrough([string:reverse(String)]) end),
     ?assertEqual(string:strip("  ABC  "), "CBA"),
     meck:unload(string).
+
+self_meck_explicit_passthrough_test() ->
+    try 
+        meck:new(meck, [passthrough]),
+        meck:expect(meck, expect, fun(M, F, E) -> meck:passthrough([M, F, E]) end),
+        meck:new(meck_test_module),
+        meck:expect(meck_test_module, b, fun() -> ok end)
+    after 
+        meck:unload(meck_test_module),
+        meck:unload(meck)
+    end.    
 
 sticky_directory_test_() ->
     {foreach, fun sticky_setup/0, fun sticky_teardown/1,


### PR DESCRIPTION
Before this change calling a mocked function from inside
an expectation fun, and then calling meck:passthrough/1
raises an exception. This happens because the current
function state is invalidated by the mocked function.

This is a follow on change to https://github.com/eproxus/meck/pull/232 
solving the problem in a more general way. 