### PR TITLE
Support Erlang 27.0

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -7,22 +7,21 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Erlang ${{matrix.otp}} / rebar ${{matrix.rebar3}}
     strategy:
       matrix:
-        otp: ['24', '25', '26']
-        rebar3: ['3']
+        otp: ["25", "26", "27"]
+        rebar3: ["3"]
     steps:
-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           rebar3-version: ${{matrix.rebar3}}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         env:
           cache-name: rebar3
         with:

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
+{minimum_otp_vsn, "25.0"}.
+
 {profiles, [
     {test, [
         {deps, [unite]},

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -1348,31 +1348,28 @@ remote_meck_test_() ->
 
 remote_setup() ->
     [] = os:cmd("epmd -daemon"),
-    Hostname = case node() of
-      'nonode@nohost' -> "localhost";
-      _               -> test_server_sup:hoststr()
-    end,
-    Myself = list_to_atom("meck_eunit_test@" ++ Hostname),
-    net_kernel:start([Myself, shortnames]),
-    {ok, Node} = slave:start_link(list_to_atom(Hostname), meck_remote_test,
-                                  "-pa \"" ++ test_dir() ++ "\""),
+    net_kernel:start([meck_eunit_test]),
+    {ok, Pid, Node} = peer:start_link(#{
+        name => meck_remote_test,
+        args => ["-pa", test_dir()]
+    }),
     {Mod, Bin, File} = code:get_object_code(meck),
     true = rpc:call(Node, code, add_path, [filename:dirname(File)]),
     {module, Mod} = rpc:call(Node, code, load_binary, [Mod, File, Bin]),
     {module, meck_test_module} =
         rpc:call(Node, code, load_file, [meck_test_module]),
-    {Node, meck_test_module}.
+    {Pid, Node, meck_test_module}.
 
-remote_teardown({Node, _Mod}) ->
-    ok = slave:stop(Node),
+remote_teardown({Pid, _Node, _Mod}) ->
+    ok = peer:stop(Pid),
     ok = net_kernel:stop().
 
-remote_meck_({Node, Mod}) ->
+remote_meck_({_Pid, Node, Mod}) ->
     ?assertEqual(ok, rpc:call(Node, meck, new, [Mod, [no_link, non_strict]])),
     ?assertEqual(ok, rpc:call(Node, meck, expect, [Mod, test, 0, true])),
     ?assertEqual(true, rpc:call(Node, Mod, test, [])).
 
-remote_meck_cover_({Node, Mod}) ->
+remote_meck_cover_({_Pid, Node, Mod}) ->
     {ok, Mod} = cover:compile(test_file(Mod, ".erl")),
     {ok, _Nodes} = cover:start([Node]),
     ?assertEqual(ok, rpc:call(Node, meck, new, [Mod])).


### PR DESCRIPTION
- Removes no-longer supported OTP version 24
- Migrates from `slave` to `peer` in test code.
