### PR TITLE
Fix an issue with the code coverage in Erlang.mk

### DIFF
--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -660,7 +660,13 @@ cleanup(Mod) ->
     code:purge(Mod),
     code:delete(Mod),
     code:purge(meck_util:original_name(Mod)),
-    code:delete(meck_util:original_name(Mod)).
+    Res = code:delete(meck_util:original_name(Mod)),
+
+    % `cover:export` might still export the meck generated module, 
+    % make sure that does not happen.
+    _ = cover:reset(meck_util:original_name(Mod)),
+
+    Res.
 
 -spec times_called(OptFunc::'_' | atom(),
                    meck_args_matcher:args_matcher(),

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -1181,6 +1181,30 @@ cover_passthrough_test() ->
     ?assertEqual({ok, {meck_test_module, {2,1}}},
                  cover:analyze(meck_test_module, module)).
 
+cover_no_meck_original_in_cover_export_test() ->
+    {ok, _} = cover:compile("test/meck_test_module.erl"),
+
+    passthrough_test([]),
+
+    Filename =
+        lists:flatten(
+            io_lib:format(
+                "tmp_~b_~p.coverdata",
+                [rand:uniform(100_000), meck_util:original_name(meck_test_module)]
+            )
+        ),
+    try
+        ok = cover:export(Filename),
+        ok = cover:import(Filename)
+    after
+        _ = file:delete(Filename)
+    end,
+
+    ?assertNot(
+        lists:member(meck_util:original_name(meck_test_module), cover:imported_modules()),
+        "the meck generated module should not be in the exported cover data"
+    ).
+
 cover_path_test() ->
     {ok, _} = cover:compile("test/meck_test_module.erl"),
     ?assertEqual({ok, {meck_test_module, {0,3}}},


### PR DESCRIPTION
It seems that just purging away the meck generated module (in `meck:unload`) is not removing it from the cover data. Exporting the cover data using `cover:export/1` will also export data about the meck generated module. Erlang.mk [uses](https://github.com/ninenines/erlang.mk/blob/b8a27ab752389394bfdb8c15d1b69455c313991e/plugins/cover.mk#L52) the export & import flow to generate the HTML coverage report, so the report will show the purged module - which is not correct.

This might be due to an issue in the coverage tool and it would be better to investigate and fix it there, but this fix shouldn't break anything, so I think it is acceptable.