### PR TITLE
Add meck:capture(..., result)

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -728,9 +728,11 @@ capture(Occur, Mod, Func, OptArgsSpec, ArgNum, OptCallerPid) ->
       Func::atom(),
       OptArgsSpec :: args_spec(),
       ArgNum :: pos_integer(),
-      ArgValue :: any().
-capture(Occur, Mod, Func, OptArgsSpec, ArgNum) ->
-    meck_history:capture(Occur, '_', Mod, Func, OptArgsSpec, ArgNum).
+      ArgValue :: any() | result.
+capture(Occur, Mod, Func, OptArgsSpec, ArgNum) when is_integer(ArgNum), ArgNum >= 1 ->
+    meck_history:capture(Occur, '_', Mod, Func, OptArgsSpec, ArgNum);
+capture(Occur, Mod, Func, OptArgsSpec, _ArgNum = result) ->
+    meck_history:result(Occur, '_', Mod, Func, OptArgsSpec).
 
 %% @doc Returns the currently mocked modules.
 -spec mocked() -> list(atom()).

--- a/test/meck_history_tests.erl
+++ b/test/meck_history_tests.erl
@@ -105,10 +105,10 @@ result_different_positions() ->
     test:bar(1007, 2007, 3007),
     test:foo(1008, 2008, 3008),
     %% Then
-    ?assertMatch(2003, meck_history:result(first, '_', test, foo, ['_', '_', '_'])),
-    ?assertMatch(2008, meck_history:result(last, '_', test, foo, ['_', '_', '_'])),
-    ?assertMatch(2006, meck_history:result(3, '_', test, foo, ['_', '_', '_'])),
-    ?assertError(not_found, meck_history:result(5, '_', test, foo, ['_', '_', '_'])).
+    ?assertMatch(2003, meck:capture(first, test, foo, ['_', '_', '_'], result)),
+    ?assertMatch(2008, meck:capture(last, test, foo, ['_', '_', '_'], result)),
+    ?assertMatch(2006, meck:capture(3, test, foo, ['_', '_', '_'], result)),
+    ?assertError(not_found, meck:capture(5, test, foo, ['_', '_', '_'], result)).
 
 result_different_args_specs() ->
     meck:expect(test, foo, fun(_, A) -> A end),


### PR DESCRIPTION
See #249

I'm not sure whether we want to deprecate the use of `meck_history:result()`, so I only changed one of the unit tests to use the changed `meck:capture()`.

Let me know what direction you prefer, and I'll change the PR.