### PR TITLE
Make mecked modules debuggable by EDB

### DIFF
--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -230,6 +230,7 @@ init([Mod, Options]) ->
     History = if NoHistory -> undefined; true -> [] end,
     CanExpect = resolve_can_expect(Mod, Exports, Options),
     Expects = init_expects(Exports, Options),
+    backup_original_edb_breakpoints(Mod),
     process_flag(trap_exit, true),
     try
         Forms = meck_code_gen:to_forms(Mod, Expects),
@@ -352,6 +353,7 @@ terminate(_Reason, #state{mod = Mod, original = OriginalState,
                           was_sticky = WasSticky, restore = Restore}) ->
     BackupCover = export_original_cover(Mod, OriginalState),
     cleanup(Mod),
+    restore_original_edb_breakpoints(Mod),
     restore_original(Mod, OriginalState, WasSticky, BackupCover),
     case Restore andalso false =:= code:is_loaded(Mod) of
         true ->
@@ -441,6 +443,10 @@ backup_original(Mod, Passthrough, NoPassCover, EnableOnLoad) ->
                 false -> {Cover, no_binary}
             end
     end.
+
+-spec backup_original_edb_breakpoints(module()) -> ok.
+backup_original_edb_breakpoints(Mod) ->
+    handle_original_edb_breakpoints(Mod, backup).
 
 -spec get_cover_state(Mod::atom()) ->
         {File::string(), Data::string(), CompileOptions::[any()]} | false.
@@ -633,6 +639,28 @@ restore_original(Mod, {{File, OriginalCover, Options}, _Bin}, WasSticky, BackupC
     ok = cover:import(OriginalCover),
     ok = file:delete(OriginalCover),
     ok.
+
+-spec restore_original_edb_breakpoints(module()) -> ok.
+restore_original_edb_breakpoints(Mod) ->
+    handle_original_edb_breakpoints(Mod, restore).
+
+-spec handle_original_edb_breakpoints(module(), Action :: atom()) -> ok.
+handle_original_edb_breakpoints(Mod, Action) ->
+    EdbServerModule = edb_server,
+    case code:is_loaded(EdbServerModule) of
+        false -> ok;
+        _ ->
+            try
+                case Action of
+                    backup ->
+                        EdbServerModule:add_module_substitute(Mod, meck_util:original_name(Mod), [{meck_code_gen, eval, 5}]);
+                    restore ->
+                        EdbServerModule:remove_module_substitute(meck_util:original_name(Mod))
+                end
+            catch
+                _:_ -> ok
+            end
+    end.
 
 %% @doc Export the cover data for `<name>_meck_original' and modify
 %% the data so it can be imported under `<name>'.


### PR DESCRIPTION
As part of the [EDB debugger](https://github.com/WhatsApp/edb), we want to make sure that the debugger works even in presence of mocks.

For this, we added [two functions](https://github.com/WhatsApp/edb/blob/93ea27c0d3233c1f64a5ee165cd1c8720f20451a/edb_core/src/edb_server.erl#L163-L194) to the EDB server to allow "module substitution".

A mocking library such as meck would need to invoke these two functions during initialization/termination, as showcased in this PR which was originally designed by @jcpetruzza and @agastyabahl.

If the direct reference to `edb_server` is not acceptable, we can use an env variable or equivalent approach to configure the "hook".