### PR TITLE
Fix tests with short domain names (default)

### DIFF
--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -1372,7 +1372,7 @@ remote_meck_test_() ->
 
 remote_setup() ->
     [] = os:cmd("epmd -daemon"),
-    net_kernel:start([meck_eunit_test]),
+    net_kernel:start([meck_eunit_test, shortnames]),
     {ok, Pid, Node} = peer:start_link(#{
         name => meck_remote_test,
         args => ["-pa", test_dir()]


### PR DESCRIPTION
THis change was introduced in commit
dfb47c544bdf14b5c26ff2651cf9339dbbe2f50e and likely just an oversight.