### PR TITLE
Fix case for concurrent tests encountering already-started cover

### DIFF
--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -453,6 +453,7 @@ backup_original(Mod, Passthrough, NoPassCover, EnableOnLoad) ->
 -spec get_cover_state(Mod::atom()) ->
         {File::string(), Data::string(), CompileOptions::[any()]} | false.
 get_cover_state(Mod) ->
+    ok = start_cover(),
     case cover:is_compiled(Mod) of
         {file, File} ->
             OriginalCover = meck_cover:dump_coverdata(Mod),
@@ -465,6 +466,13 @@ get_cover_state(Mod) ->
             {File, OriginalCover, CompileOptions};
         _ ->
             false
+    end.
+
+-spec start_cover() -> ok.
+start_cover() ->
+    case cover:start() of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
     end.
 
 -spec resolve_can_expect(Mod::atom(),


### PR DESCRIPTION
When two concurrent meck initializations both see the cover server as not running (noproc), whichever calls start() second gets {error, {already_started, Pid}} — but OTP pattern-matches {ok, _} in cover.erl inside call/1, so it crashes.

In meck by explicitly starting cover before calling cover:is_compiled/1, the already_started case is handled, such that cover:call/1 never sees noproc.

Encountered this problem in an Elixir codebase with async tests that use meck, running on CI:

```
     ** (EXIT from #PID<0.753.0>) an exception was raised:
           ** (MatchError) no match of right hand side value: {:error, {:already_started, #PID<0.765.0>}}
               (tools 4.1.1) cover.erl:1146: :cover.call/1
               (meck 1.1.0) <APP_ROOT>/deps/meck/src/meck_proc.erl:456::meck_proc.get_cover_state/1
               (meck 1.1.0) <APP_ROOT>/deps/meck/src/meck_proc.erl:408::meck_proc.backup_original/4
               (meck 1.1.0) <APP_ROOT>/deps/meck/src/meck_proc.erl:234::meck_proc.init/1
               (stdlib 6.2.2.3) gen_server.erl:2229: :gen_server.init_it/2
               (stdlib 6.2.2.3) gen_server.erl:2184: :gen_server.init_it/6
               (stdlib 6.2.2.3) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```